### PR TITLE
fixed AppAuth bug, when url contained spaces(OCS calls)

### DIFF
--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -119,7 +119,7 @@ class NcSessionBasic(ABC):
         elif json is not None:
             headers.update({"Content-Type": "application/json"})
             data_bytes = dumps(json).encode("utf-8")
-        return self._ocs(method, f"{path}?{urlencode(params, True)}", headers, data=data_bytes, **kwargs)
+        return self._ocs(method, f"{quote(path)}?{urlencode(params, True)}", headers, data=data_bytes, **kwargs)
 
     def _ocs(self, method: str, path_params: str, headers: dict, data: Optional[bytes], **kwargs):
         self.init_adapter()

--- a/nc_py_api/users_statuses.py
+++ b/nc_py_api/users_statuses.py
@@ -45,14 +45,9 @@ class UsersStatusesAPI:
         data = kwargs_to_dict(["limit", "offset"], limit=limit, offset=offset)
         return self._session.ocs(method="GET", path=f"{ENDPOINT}/statuses", params=data)
 
-    def get_current(self) -> Optional[CurrentUserStatus]:
+    def get_current(self) -> CurrentUserStatus:
         require_capabilities("user_status", self._session.capabilities)
-        try:
-            return self._session.ocs(method="GET", path=f"{ENDPOINT}/user_status")
-        except NextcloudException as e:
-            if e.status_code == 404:
-                return None
-            raise e from None
+        return self._session.ocs(method="GET", path=f"{ENDPOINT}/user_status")
 
     def get(self, user_id: str) -> Optional[UserStatus]:
         require_capabilities("user_status", self._session.capabilities)
@@ -108,7 +103,8 @@ class UsersStatusesAPI:
                 return None
             raise e from None
 
-    def restore_backup_status(self, message_id: str) -> None:  # to-do: test it, currently it is untested
-        require_capabilities("user_status>", self._session.capabilities)
+    def restore_backup_status(self, message_id: str) -> Optional[CurrentUserStatus]:
+        require_capabilities("user_status", self._session.capabilities)
         require_capabilities("restore", self._session.capabilities["user_status"])
-        self._session.ocs(method="DELETE", path=f"{ENDPOINT}/user_status/revert/{message_id}")
+        result = self._session.ocs(method="DELETE", path=f"{ENDPOINT}/user_status/revert/{message_id}")
+        return result if result else None

--- a/nc_py_api/users_statuses.py
+++ b/nc_py_api/users_statuses.py
@@ -90,18 +90,12 @@ class UsersStatusesAPI:
             params["statusIcon"] = status_icon
         self._session.ocs(method="PUT", path=f"{ENDPOINT}/user_status/message/custom", params=params)
 
-    def get_backup_status(self, user_id: str):  # -> Optional[UserStatus]: to-do: test it, currently it is untested
+    def get_backup_status(self, user_id: str = "") -> Optional[UserStatus]:
         require_capabilities("user_status", self._session.capabilities)
-        if not user_id:
-            user_id = self._session.user
+        user_id = user_id if user_id else self._session.user
         if not user_id:
             raise ValueError("user_id can not be empty.")
-        try:
-            return self._session.ocs(method="GET", path=f"{ENDPOINT}/user_status/_{user_id}")
-        except NextcloudException as e:
-            if e.status_code == 404:
-                return None
-            raise e from None
+        return self.get(f"_{user_id}")
 
     def restore_backup_status(self, message_id: str) -> Optional[CurrentUserStatus]:
         require_capabilities("user_status", self._session.capabilities)

--- a/tests/users_statuses_test.py
+++ b/tests/users_statuses_test.py
@@ -2,7 +2,6 @@ import pytest
 
 from time import time
 
-
 from gfixture import NC_TO_TEST
 
 
@@ -34,6 +33,11 @@ def test_get_status(nc, message):
     assert r1["message"] == message
     assert r1["messageId"] is None
     assert not r1["messageIsPredefined"]
+
+
+@pytest.mark.parametrize("nc", NC_TO_TEST)
+def test_get_status_non_existent_user(nc):
+    assert nc.users_statuses.get("no such user") is None
 
 
 @pytest.mark.parametrize("nc", NC_TO_TEST)
@@ -105,3 +109,8 @@ def test_set_predefined(nc, clear_at):
             assert r["messageId"] == i["id"]
             assert r["messageIsPredefined"]
             assert r["clearAt"] == clear_at
+
+
+@pytest.mark.parametrize("nc", NC_TO_TEST)
+def test_restore_from_non_existing_backup_status(nc):
+    assert nc.users_statuses.restore_backup_status("no such backup status") is None

--- a/tests/users_statuses_test.py
+++ b/tests/users_statuses_test.py
@@ -113,5 +113,23 @@ def test_set_predefined(nc, clear_at):
 
 @pytest.mark.parametrize("nc", NC_TO_TEST)
 @pytest.mark.skipif(NC_VERSION["major"] < 27, reason="Run only on NC27+")
-def test_restore_from_non_existing_backup_status(nc):
+def test_get_back_status_from_from_empty_user(nc):
+    orig_user = nc._session.user
+    nc._session.user = ""
+    try:
+        with pytest.raises(ValueError):
+            nc.users_statuses.get_backup_status("")
+    finally:
+        nc._session.user = orig_user
+
+
+@pytest.mark.parametrize("nc", NC_TO_TEST)
+@pytest.mark.skipif(NC_VERSION["major"] < 27, reason="Run only on NC27+")
+def test_get_back_status_from_from_non_exist_user(nc):
+    assert nc.users_statuses.get_backup_status("mёm_m-m.l") is None
+
+
+@pytest.mark.parametrize("nc", NC_TO_TEST)
+@pytest.mark.skipif(NC_VERSION["major"] < 27, reason="Run only on NC27+")
+def test_restore_from_non_existing_back_status(nc):
     assert nc.users_statuses.restore_backup_status("no such backup status") is None

--- a/tests/users_statuses_test.py
+++ b/tests/users_statuses_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from time import time
 
-from gfixture import NC_TO_TEST
+from gfixture import NC_TO_TEST, NC_VERSION
 
 
 @pytest.mark.parametrize("nc", NC_TO_TEST)
@@ -112,5 +112,6 @@ def test_set_predefined(nc, clear_at):
 
 
 @pytest.mark.parametrize("nc", NC_TO_TEST)
+@pytest.mark.skipif(NC_VERSION["major"] < 27, reason="Run only on NC27+")
 def test_restore_from_non_existing_backup_status(nc):
     assert nc.users_statuses.restore_backup_status("no such backup status") is None


### PR DESCRIPTION
Fixed situation when url(not parameter) contained spaces in OCS calls + test that covers this.
