### PR TITLE
initial commit for future SharesAPI

### DIFF
--- a/nc_py_api/constants.py
+++ b/nc_py_api/constants.py
@@ -34,3 +34,23 @@ class OCSRespond(IntEnum):
     RESPOND_UNAUTHORISED = 997
     RESPOND_NOT_FOUND = 998
     RESPOND_UNKNOWN_ERROR = 999
+
+
+class ShareType(IntEnum):
+    TYPE_USER = 0
+    TYPE_GROUP = 1
+    TYPE_LINK = 3
+    TYPE_EMAIL = 4
+    TYPE_REMOTE = 6
+    TYPE_CIRCLE = 7
+    TYPE_GUEST = 8
+    TYPE_REMOTE_GROUP = 9
+    TYPE_ROOM = 10
+    TYPE_DECK = 11
+    TYPE_SCIENCEMESH = 15
+
+
+class ShareStatus(IntEnum):
+    STATUS_PENDING = 0
+    STATUS_ACCEPTED = 1
+    STATUS_REJECTED = 2

--- a/nc_py_api/files_sharing.py
+++ b/nc_py_api/files_sharing.py
@@ -1,0 +1,30 @@
+"""
+Nextcloud API for working with files shares.
+"""
+
+from typing import Union
+
+from ._session import NcSessionBasic
+from .files import FsNode
+
+ENDPOINT_BASE_SHARES = "/ocs/v1.php/shares"
+ENDPOINT_BASE_SHAREES = "/ocs/v1.php/sharees"
+ENDPOINT_BASE_DELETED = "/ocs/v1.php/deletedshares"
+ENDPOINT_BASE_REMOTE = "/ocs/v1.php/remote_shares"
+
+
+class FilesSharingAPI:
+    def __init__(self, session: NcSessionBasic):
+        self._session = session
+
+    def get_list(self, shared_with_me=False, reshares=False, subfiles=False, path: Union[str, FsNode] = ""):
+        params = {
+            "shared_with_me": "true" if shared_with_me else "false",
+            "reshares": "true" if reshares else "false",
+            "subfiles": "true" if subfiles else "false",
+            "path": path,
+        }
+        return self._session.ocs(method="GET", path=f"{ENDPOINT_BASE_SHARES}", params=params)
+
+    def create(self, path: Union[str, FsNode], permissions):
+        pass

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -11,6 +11,7 @@ from .appconfig_preferences_ex import AppConfigExAPI, PreferencesExAPI
 from .apps import AppAPI
 from .constants import APP_V2_BASIC_URL, ApiScope, LogLvl
 from .files import FilesAPI
+from .files_sharing import FilesSharingAPI
 from .misc import check_capabilities
 from .preferences import PreferencesAPI
 from .theming import ThemingInfo, get_parsed_theme
@@ -24,6 +25,7 @@ from .weather_status import WeatherStatusAPI
 class NextcloudBasic(ABC):
     apps: AppAPI
     files: FilesAPI
+    files_sharing: FilesSharingAPI
     preferences_api: PreferencesAPI
     users: UsersAPI
     users_groups: UserGroupsAPI
@@ -34,6 +36,7 @@ class NextcloudBasic(ABC):
     def _init_api(self, session: NcSessionBasic):
         self.apps = AppAPI(session)
         self.files = FilesAPI(session)
+        self.files_sharing = FilesSharingAPI(session)
         self.preferences_api = PreferencesAPI(session)
         self.users = UsersAPI(session)
         self.users_groups = UserGroupsAPI(session)


### PR DESCRIPTION
Before developing `sharing api`, need to implement bridge between `shares` permissions which is `int` and filesystem permissions which type is `str`, so it is first task.

- [ ] Unify FilesAPI and SharesAPI `permissions`
- [ ] Implement creating, deleting, listing SharesAPI
- [ ] Wrote tests for creating, deleting, listing SharesAPI
- [ ] Wrote `docstrings` for what parameters mean in each method.