### PR TITLE
`options` rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.27 - 2023-08-03]
+## [0.0.27 - 2023-08-05]
 
 ### Added
 
 - `Notifications API`
+- `options` now independent in each `Nextcloud` class. They can be specified in kwargs, environment or `.env` files.
 
 ### Changed
 

--- a/docs/Options.rst
+++ b/docs/Options.rst
@@ -6,6 +6,6 @@ Options
 -------
 
 .. autodata:: nc_py_api.options.XDEBUG_SESSION
-.. autodata:: nc_py_api.options.TIMEOUT
-.. autodata:: nc_py_api.options.TIMEOUT_DAV
-.. autodata:: nc_py_api.options.VERIFY_NC_CERTIFICATE
+.. autodata:: nc_py_api.options.NPA_TIMEOUT
+.. autodata:: nc_py_api.options.NPA_TIMEOUT_DAV
+.. autodata:: nc_py_api.options.NPA_NC_CERT

--- a/nc_py_api/options.py
+++ b/nc_py_api/options.py
@@ -22,4 +22,4 @@ NPA_NC_CERT = environ.get("NPA_NC_CERT", True)
 """Option to enable/disable Nextcloud certificate verification.
 
 SSL certificates (a.k.a CA bundle) used to  verify the identity of requested hosts. Either `True` (default CA bundle),
- a path to an SSL certificate file, or `False` (which will disable verification)."""
+a path to an SSL certificate file, or `False` (which will disable verification)."""

--- a/nc_py_api/options.py
+++ b/nc_py_api/options.py
@@ -1,15 +1,25 @@
-"""Options to change nc_py_api's runtime behaviour."""
+"""Options to change nc_py_api's runtime behavior.
 
-XDEBUG_SESSION = "PHPSTORM"
-"""Dev option, for debugging PHP code"""
+Each setting only affects newly created instances of the Nextcloud or NextcloudApp class, unless otherwise specified.
+Refer to the documentation for information in which different ways it can be useful.
+"""
+from os import environ
 
-TIMEOUT = 50
+from dotenv import load_dotenv
+
+load_dotenv()
+
+XDEBUG_SESSION = environ.get("XDEBUG_SESSION", "")
+"""Dev option, for debugging PHP code."""
+
+NPA_TIMEOUT = environ.get("NPA_TIMEOUT", 50)
 """Default timeout for OCS API calls. Set to "None" to disable timeouts for development."""
 
-TIMEOUT_DAV = TIMEOUT * 3 if TIMEOUT else None
+NPA_TIMEOUT_DAV = environ.get("NPA_TIMEOUT_DAV", NPA_TIMEOUT * 3 if isinstance(NPA_TIMEOUT, int) else None)
 """File operations timeout, usually it is OCS timeout multiplied by 3."""
 
-VERIFY_NC_CERTIFICATE = True
-"""Option to enable/disable Nextcloud certificate verification
+NPA_NC_CERT = environ.get("NPA_NC_CERT", True)
+"""Option to enable/disable Nextcloud certificate verification.
 
-In the case of self-signed certificates, you can disable verification."""
+SSL certificates (a.k.a CA bundle) used to  verify the identity of requested hosts. Either `True` (default CA bundle),
+ a path to an SSL certificate file, or `False` (which will disable verification)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,16 +43,17 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "fastapi==0.101",
-  "httpx==0.24.1",
-  "pydantic==2.1.1",
-  "requests==2.31",
-  "xmltodict==0.13",
+  "fastapi>=0.101",
+  "httpx>=0.24.1",
+  "pydantic>=2.1.1",
+  "python-dotenv>=1",
+  "requests>=2.31",
+  "xmltodict>=0.13",
 ]
 [project.optional-dependencies]
 app = [
-  "uvicorn[standard]==0.23.2",
-  "xxhash==3.3",
+  "uvicorn[standard]>=0.23.2",
+  "xxhash>=3.3",
 ]
 bench = [
   "matplotlib",

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -39,10 +39,10 @@ def test_require_capabilities():
 
 
 def test_config_get_value():
-    BasicConfig()._get_value("non_exist_value", raise_not_found=False)
+    BasicConfig()._get_config_value("non_exist_value", raise_not_found=False)
     with pytest.raises(ValueError):
-        BasicConfig()._get_value("non_exist_value")
-    assert BasicConfig()._get_value("non_exist_value", non_exist_value=123) == 123
+        BasicConfig()._get_config_value("non_exist_value")
+    assert BasicConfig()._get_config_value("non_exist_value", non_exist_value=123) == 123
 
 
 def test_deffered_error():


### PR DESCRIPTION
Allows to specify `options` throw environment variables or `.env` file.

Also `options` now are independent in each `Nextcloud` or `NextcloudApp` class, and this allows to specify them with `kwargs`