### PR TITLE
fix+test for users.create(groups=xxx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - Finished documentation.
 - Different small adjustments to API, to be it more consistent.
 
+### Fixed
+
+- Assign groups in user creation
+
 ## [0.0.27 - 2023-08-05]
 
 ### Added

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -70,7 +70,7 @@ class UsersAPI:
             * ``password`` - password that should be set for user.
             * ``email`` - email of the new user. If ``password`` is not provided, then this field should be filled.
             * ``displayname`` - display name of the new user.
-            * ``groups`` - groups IDs to which user belongs.
+            * ``groups`` - list of groups IDs to which user belongs.
             * ``subadmin`` - boolean indicating is user should be the subadmin.
             * ``quota`` - quota for the user, if needed.
             * ``language`` - default language for the user.
@@ -83,7 +83,7 @@ class UsersAPI:
         for k in ("password", "displayname", "email", "groups", "subadmin", "quota", "language"):
             if k in kwargs:
                 data[k] = kwargs[k]
-        self._session.ocs(method="POST", path=ENDPOINT, params=data)
+        self._session.ocs(method="POST", path=ENDPOINT, json=data)
 
     def delete(self, user_id: str) -> None:
         """Deletes user from the Nextcloud server.

--- a/tests/users_test.py
+++ b/tests/users_test.py
@@ -45,6 +45,20 @@ def test_create_user(nc):
     nc.users.create(TEST_USER_NAME, password=TEST_USER_PASSWORD)
     with pytest.raises(NextcloudException):
         nc.users.create(TEST_USER_NAME, password=TEST_USER_PASSWORD)
+    nc.users.delete(TEST_USER_NAME)
+
+
+@pytest.mark.skipif(not isinstance(NC_TO_TEST[:1][0], Nextcloud), reason="Not available for NextcloudApp.")
+@pytest.mark.parametrize("nc", NC_TO_TEST[:1])
+def test_create_user_with_groups(nc):
+    try:
+        nc.users.delete(TEST_USER_NAME)
+    except NextcloudException:
+        pass
+    nc.users.create(TEST_USER_NAME, password=TEST_USER_PASSWORD, groups=["admin"])
+    admin_group = nc.users.groups.get_members("admin")
+    assert TEST_USER_NAME in admin_group
+    nc.users.delete(TEST_USER_NAME)
 
 
 @pytest.mark.skipif(not isinstance(NC_TO_TEST[:1][0], Nextcloud), reason="Not available for NextcloudApp.")


### PR DESCRIPTION
```python3

nc.users.create(TEST_USER_NAME, password=TEST_USER_PASSWORD, groups=["admin"])
```

now works.