### PR TITLE
AppEcosystem -> AppAPI refactor(1)

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -117,16 +117,16 @@ jobs:
         working-directory: nc_py_api
         run: python3 -m pip -v install ".[dev]"
 
-      - name: Checkout AppEcosystemV2
+      - name: Checkout AppAPI
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
         with:
-          path: apps/app_ecosystem_v2
-          repository: cloud-py-api/app_ecosystem_v2
+          path: apps/app_api
+          repository: cloud-py-api/app_api
 
-      - name: Install AppEcosystemV2
+      - name: Install AppAPI
         run: |
-          patch -p 1 -i apps/app_ecosystem_v2/base_php.patch
-          php occ app:enable app_ecosystem_v2
+          patch -p 1 -i apps/app_api/base_php.patch
+          php occ app:enable app_api
           cd nc_py_api
           coverage run --data-file=.coverage.ci_install tests/_install.py &
           echo $! > /tmp/_install.pid
@@ -272,18 +272,18 @@ jobs:
         working-directory: nc_py_api
         run: python3 -m pip -v install ".[dev]"
 
-      - name: Checkout AppEcosystemV2
+      - name: Checkout AppAPI
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
         if: ${{ !startsWith(matrix.nextcloud, '26.') }}
         with:
-          path: apps/app_ecosystem_v2
-          repository: cloud-py-api/app_ecosystem_v2
+          path: apps/app_api
+          repository: cloud-py-api/app_api
 
-      - name: Install AppEcosystemV2
+      - name: Install AppAPI
         if: ${{ !startsWith(matrix.nextcloud, '26.') }}
         run: |
-          patch -p 1 -i apps/app_ecosystem_v2/base_php.patch
-          php occ app:enable app_ecosystem_v2
+          patch -p 1 -i apps/app_api/base_php.patch
+          php occ app:enable app_api
           cd nc_py_api
           coverage run --data-file=.coverage.ci_install tests/_install.py &
           echo $! > /tmp/_install.pid
@@ -416,16 +416,16 @@ jobs:
         working-directory: nc_py_api
         run: python3 -m pip -v install ".[dev]"
 
-      - name: Checkout AppEcosystemV2
+      - name: Checkout AppAPI
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
         with:
-          path: apps/app_ecosystem_v2
-          repository: cloud-py-api/app_ecosystem_v2
+          path: apps/app_api
+          repository: cloud-py-api/app_api
 
-      - name: Install AppEcosystemV2
+      - name: Install AppAPI
         run: |
-          patch -p 1 -i apps/app_ecosystem_v2/base_php.patch
-          php occ app:enable app_ecosystem_v2
+          patch -p 1 -i apps/app_api/base_php.patch
+          php occ app:enable app_api
           cd nc_py_api
           coverage run --data-file=.coverage.ci_install tests/_install.py &
           echo $! > /tmp/_install.pid
@@ -536,15 +536,15 @@ jobs:
         working-directory: nc_py_api
         run: python3 -m pip -v install ".[dev]"
 
-      - name: Checkout AppEcosystemV2
+      - name: Checkout AppAPI
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
         with:
-          path: apps/app_ecosystem_v2
-          repository: cloud-py-api/app_ecosystem_v2
+          path: apps/app_api
+          repository: cloud-py-api/app_api
 
-      - name: Install AppEcosystemV2
+      - name: Install AppAPI
         run: |
-          php occ app:enable app_ecosystem_v2
+          php occ app:enable app_api
           cd nc_py_api
           coverage run --data-file=.coverage.ci_install tests/_install.py &
           echo $! > /tmp/_install.pid
@@ -799,19 +799,19 @@ jobs:
         working-directory: nc_py_api
         run: python3 -m pip -v install ".[dev]"
 
-      - name: Checkout AppEcosystemV2
+      - name: Checkout AppAPI
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
         with:
-          path: apps/app_ecosystem_v2
-          repository: cloud-py-api/app_ecosystem_v2
+          path: apps/app_api
+          repository: cloud-py-api/app_api
 
       - name: Patch base.php
         if: ${{ startsWith(matrix.nextcloud, 'stable26') }}
-        run: patch -p 1 -i apps/app_ecosystem_v2/base_php.patch
+        run: patch -p 1 -i apps/app_api/base_php.patch
 
-      - name: Install AppEcosystemV2
+      - name: Install AppAPI
         run: |
-          php occ app:enable app_ecosystem_v2
+          php occ app:enable app_api
           cd nc_py_api
           coverage run --data-file=.coverage.ci_install tests/_install.py &
           echo $! > /tmp/_install.pid

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -705,7 +705,7 @@ jobs:
           coverage run --data-file=.coverage.at_the_end -m pytest tests/_tests_at_the_end.py
           coverage combine && coverage xml && coverage html
         env:
-          SKIP_AE_TESTS: 1
+          SKIP_AA_TESTS: 1
           NPA_NC_CERT: ''
 
       - name: HTML coverage to artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0 - 2023-09-11]
+
+### Changed
+
+- AppEcosystem_V2 Project was renamed to App_API, adjust all routes, examples, and docs for this.
+- The Application Authentication mechanism was changed to a much simple one.
+
 ## [0.1.0 - 2023-09-06]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The **Nextcloud** class functions as a standard Nextcloud client,
 enabling you to make API requests using a username and password.
 
 On the other hand, the **NextcloudApp** class is designed for creating applications for Nextcloud.<br>
-It uses the [AppEcosystem](https://github.com/cloud-py-api/app_ecosystem_v2) to allow
+It uses the [AppAPI](https://github.com/cloud-py-api/app_api) to allow
 applications to impersonate users through a separate authentication mechanism.
 
 Both classes offer most of the same APIs,

--- a/docs/DevSetup.rst
+++ b/docs/DevSetup.rst
@@ -10,7 +10,7 @@ Suggested IDE: **PyCharm**, but of course you can use any IDE you like for this 
 Steps to setup up the development environment:
 
 #. Setup Nextcloud locally or remotely.
-#. Install `AppEcosystem <https://github.com/cloud-py-api/app_ecosystem_v2>`_, follow it's steps to register ``deploy daemon`` if needed.
+#. Install `AppAPI <https://github.com/cloud-py-api/app_api>`_, follow it's steps to register ``deploy daemon`` if needed.
 #. Clone the `nc_py_api <https://github.com/cloud-py-api/nc_py_api>`_ with :command:`shell`::
 
     git clone https://github.com/cloud-py-api/nc_py_api.git
@@ -39,7 +39,7 @@ Steps to setup up the development environment:
 
     pre-commit install
 
-#. If ``deploy daemon`` is registered for AppEcosystem, register **nc_py_api** as an application with :command:`shell`::
+#. If ``deploy daemon`` is registered for AppAPI, register **nc_py_api** as an application with :command:`shell`::
 
     make register28
 

--- a/docs/NextcloudApp.rst
+++ b/docs/NextcloudApp.rst
@@ -1,7 +1,7 @@
 Writing a Nextcloud Application
 ===============================
 
-This chapter assumes that you are already familiar with the `concepts <https://cloud-py-api.github.io/app_ecosystem_v2/Concepts.html>`_ of the AppEcosystem.
+This chapter assumes that you are already familiar with the `concepts <https://cloud-py-api.github.io/app_api/Concepts.html>`_ of the AppAPI.
 
 As a first step, let's take a look at the structure of a basic Python application.
 
@@ -47,7 +47,7 @@ First register ``manual_install`` daemon:
 
 .. code-block:: shell
 
-    php occ app_ecosystem_v2:daemon:register manual_install "Manual Install" manual-install 0 0 0
+    php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
 
 Then, launch your application. Since this is a manual deployment, it's your responsibility to set minimum of the environment variables.
 Here they are:
@@ -56,7 +56,7 @@ Here they are:
 * APP_PORT - Port on which application listen for the requests from the Nextcloud.
 * APP_SECRET - Secret for ``hmac`` signature generation.
 * APP_VERSION - Version of the application.
-* AE_VERSION - Version of the AppEcosystem.
+* AE_VERSION - Version of the AppAPI.
 * NEXTCLOUD_URL - URL at which the application can access the Nextcloud API.
 
 You can find values for these environment variables in the **Skeleton** or **ToGif** run configurations.
@@ -65,7 +65,7 @@ After launching your application, execute the following command in the Nextcloud
 
 .. code-block:: shell
 
-    php occ app_ecosystem_v2:app:register YOUR_APP_ID manual_install --json-info \
+    php occ app_api:app:register YOUR_APP_ID manual_install --json-info \
         "{\"appid\":\"YOUR_APP_ID\",\"name\":\"YOUR_APP_DISPLAY_NAME\",\"daemon_config_name\":\"manual_install\",\"version\":\"YOU_APP_VERSION\",\"secret\":\"YOUR_APP_SECRET\",\"host\":\"host.docker.internal\",\"scopes\":{\"required\":[2, 10, 11],\"optional\":[30, 31, 32, 33]},\"port\":SELECTED_PORT,\"protocol\":\"http\",\"system_app\":0}" \
         -e --force-scopes
 
@@ -79,7 +79,7 @@ Examples for such Makefiles can be found in this repository:
 `ToGif <https://github.com/cloud-py-api/nc_py_api/blob/main/examples/as_app/to_gif/Makefile>`_ ,
 `nc_py_api <https://github.com/cloud-py-api/nc_py_api/blob/main/scripts/dev_register.sh>`_
 
-During the execution of `php occ app_ecosystem_v2:app:register`, the **enabled_handler** will be called,
+During the execution of `php occ app_api:app:register`, the **enabled_handler** will be called,
 as we pass the flag ``-e``, meaning ``enable after registration``.
 
 This is likely all you need to start debugging and developing an application for Nextcloud.
@@ -89,7 +89,7 @@ Pack & Deploy
 
 Before reading this chapter, please review the basic information about deployment
 and the currently supported types of
-`deployments configurations <https://cloud-py-api.github.io/app_ecosystem_v2/DeployConfigurations.html>`_ in the AppEcosystem documentation.
+`deployments configurations <https://cloud-py-api.github.io/app_api/DeployConfigurations.html>`_ in the AppAPI documentation.
 
 Docker Deploy Daemon
 """"""""""""""""""""
@@ -140,7 +140,7 @@ First of all, we modernize info.ixml, add the API groups we need for this to wor
         </optional>
     </scopes>
 
-.. note:: Full list of avalaible API scopes can be found `here <https://cloud-py-api.github.io/app_ecosystem_v2/tech_details/ApiScopes.html>`_.
+.. note:: Full list of avalaible API scopes can be found `here <https://cloud-py-api.github.io/app_api/tech_details/ApiScopes.html>`_.
 
 After that we extend the **enabled** handler and include there registration of the drop-down list element:
 
@@ -194,7 +194,7 @@ heavy calculations and we cannot guarantee a fast completion time, it is recomme
 an empty response (which will be a status of 200) and in the background already slowly perform operations.
 
 The last parameter is a structure describing the action and the file on which it needs to be performed,
-which is passed by the Appecosystem when clicking on the drop-down context menu of the file.
+which is passed by the AppAPI when clicking on the drop-down context menu of the file.
 
 We use the built method :py:meth:`~nc_py_api.ex_app.ui.files.UiActionFileInfo.to_fs_node` into the structure to convert it
 into a standard :py:class:`~nc_py_api.files.FsNode` class that describes the file and pass the FsNode class instance to the background task.

--- a/docs/NextcloudTalkBot.rst
+++ b/docs/NextcloudTalkBot.rst
@@ -1,7 +1,7 @@
 Nextcloud Talk Bot API in Applications
 ======================================
 
-The AppEcosystem is an excellent choice for developing and deploying bots for Nextcloud Talk.
+The AppAPI is an excellent choice for developing and deploying bots for Nextcloud Talk.
 
 Bots for Nextcloud Talk, in essence, don't differ significantly from regular external applications.
 The functionality of an external application can include just the bot or provide additional functionalities as well.

--- a/docs/benchmarks/AppAPI.rst
+++ b/docs/benchmarks/AppAPI.rst
@@ -1,7 +1,7 @@
-AppEcosystem Benchmarks
-=======================
+AppAPI Benchmarks
+=================
 
-In the current implementation, applications written and using the AppEcosystem
+In the current implementation, applications written and using the AppAPI
 so far in most cases will be authenticated at the beginning of each action.
 
 *A future enhancement that can be implemented is the addition of a session cache.
@@ -9,12 +9,12 @@ This feature would eliminate the need for re-authorization for subsequent action
 by the same user within a certain time frame.
 The implementation of this session cache would be seamless for developers and require no additional actions.*
 
-It is important to note that the AppEcosystem authentication type is currently the fastest among available options.
+It is important to note that the AppAPI authentication type is currently the fastest among available options.
 Compared to traditional username/password authentication and app password authentication,
-both of which are considerably slower, the AppEcosystem provides a significant advantage in terms of speed.
+both of which are considerably slower, the AppAPI provides a significant advantage in terms of speed.
 
 When considering data transfer speed, it is worth mentioning
-that the AppEcosystem's upload speed may be slightly lower, around 6-8 percent, for large data transfers.
+that the AppAPI's upload speed may be slightly lower, around 6-8 percent, for large data transfers.
 This decrease in speed is due to the authentication process, which involves hashing all data.
 However, for loading any data, there is no slowdown compared to standard methods.
 
@@ -26,14 +26,14 @@ this aspect is beyond the scope of the discussed issue.
 Conclusion
 ----------
 
-In summary, the AppEcosystem authentication offers fast and secure access to user data.
+In summary, the AppAPI authentication offers fast and secure access to user data.
 With the potential addition of a session cache in the future, the authentication process can become even more efficient
 and seamless for users. The slight decrease in upload speed for large data transfers
 is a trade-off for the enhanced security provided by the authentication process.
 
-Overall, the AppEcosystem authentication proves to be a reliable and effective method for application authentication.
+Overall, the AppAPI authentication proves to be a reliable and effective method for application authentication.
 
-.. _appecosystem-bench-results:
+.. _appapi-bench-results:
 
 Detailed Benchmark Results
 --------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ Have a great time with Python and Nextcloud!
    Options
    reference/index.rst
    DevSetup
-   benchmarks/AppEcosystem.rst
+   benchmarks/AppAPI.rst
 
 Indices and tables
 ==================

--- a/examples/as_app/skeleton/Makefile
+++ b/examples/as_app/skeleton/Makefile
@@ -26,24 +26,24 @@ build-push:
 
 .PHONY: deploy
 deploy:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:deploy skeleton docker_dev \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:deploy skeleton docker_dev \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
 
 .PHONY: run28
 run28:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister skeleton --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:register skeleton docker_dev -e --force-scopes \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister skeleton --silent || true
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register skeleton docker_dev -e --force-scopes \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
 
 .PHONY: run27
 run27:
-	docker exec master-stable27-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister skeleton --silent || true
-	docker exec master-stable27-1 sudo -u www-data php occ app_ecosystem_v2:app:register skeleton docker_dev -e --force-scopes \
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister skeleton --silent || true
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register skeleton docker_dev -e --force-scopes \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
 
 .PHONY: manual_register
 manual_register:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister skeleton --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:register skeleton manual_install --json-info \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister skeleton --silent || true
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register skeleton manual_install --json-info \
   "{\"appid\":\"skeleton\",\"name\":\"App Skeleton\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9030,\"scopes\":{\"required\":[],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
   -e --force-scopes

--- a/examples/as_app/talk_bot/HOW_TO_INSTALL.md
+++ b/examples/as_app/talk_bot/HOW_TO_INSTALL.md
@@ -1,19 +1,19 @@
 How To Install
 ==============
 
-Currently, while AppEcosystem hasn't been published on the App Store, and App Store support hasn't been added yet,
+Currently, while AppAPI hasn't been published on the App Store, and App Store support hasn't been added yet,
 installation is a little bit tricky.
 
 Steps to Install:
 
-1. [Install AppEcosystem](https://cloud-py-api.github.io/app_ecosystem_v2/Installation.html)
-2. Create a deployment daemon according to the [instructions](https://cloud-py-api.github.io/app_ecosystem_v2/CreationOfDeployDaemon.html#create-deploy-daemon) of the Appecosystem
-3. php occ app_ecosystem_v2:app:deploy talk_bot "daemon_deploy_name" \
+1. [Install AppEcosystem](https://cloud-py-api.github.io/app_api/Installation.html)
+2. Create a deployment daemon according to the [instructions](https://cloud-py-api.github.io/app_api/CreationOfDeployDaemon.html#create-deploy-daemon) of the AppPI
+3. php occ app_api:app:deploy talk_bot "daemon_deploy_name" \
 --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/talk_bot/appinfo/info.xml
 
     to deploy a docker image with Bot to docker.
 
-4. php occ app_ecosystem_v2:app:register talk_bot "daemon_deploy_name" -e --force-scopes \
+4. php occ app_api:app:register talk_bot "daemon_deploy_name" -e --force-scopes \
 --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/talk_bot/appinfo/info.xml
 
     to call its **enable** handler and accept all required API scopes by default.

--- a/examples/as_app/talk_bot/Makefile
+++ b/examples/as_app/talk_bot/Makefile
@@ -26,24 +26,24 @@ build-push:
 
 .PHONY: deploy
 deploy:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:deploy talk_bot docker_dev \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:deploy talk_bot docker_dev \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/talk_bot/appinfo/info.xml
 
 .PHONY: run28
 run28:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister talk_bot --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:register talk_bot docker_dev -e --force-scopes \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister talk_bot --silent || true
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register talk_bot docker_dev -e --force-scopes \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/talk_bot/appinfo/info.xml
 
 .PHONY: run27
 run27:
-	docker exec master-stable27-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister talk_bot --silent || true
-	docker exec master-stable27-1 sudo -u www-data php occ app_ecosystem_v2:app:register talk_bot docker_dev -e --force-scopes \
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister talk_bot --silent || true
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register talk_bot docker_dev -e --force-scopes \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/talk_bot/appinfo/info.xml
 
 .PHONY: manual_register
 manual_register:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister talk_bot --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:register talk_bot manual_install --json-info \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister talk_bot --silent || true
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register talk_bot manual_install --json-info \
   "{\"appid\":\"talk_bot\",\"name\":\"TalkBot\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9032,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
   -e --force-scopes

--- a/examples/as_app/to_gif/Makefile
+++ b/examples/as_app/to_gif/Makefile
@@ -27,31 +27,31 @@ build-push:
 
 .PHONY: deploy
 deploy:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:deploy to_gif docker_dev \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:deploy to_gif docker_dev \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/to_gif/appinfo/info.xml
 
 .PHONY: run28
 run28:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister to_gif --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:register to_gif docker_dev -e --force-scopes \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister to_gif --silent || true
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register to_gif docker_dev -e --force-scopes \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/to_gif/appinfo/info.xml
 
 .PHONY: manual_register28
 manual_register28:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister to_gif --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_ecosystem_v2:app:register to_gif manual_install --json-info \
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister to_gif --silent || true
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register to_gif manual_install --json-info \
   "{\"appid\":\"to_gif\",\"name\":\"to_gif\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9031,\"scopes\":{\"required\":[\"FILES\", \"NOTIFICATIONS\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
   -e --force-scopes
 
 .PHONY: run27
 run27:
-	docker exec master-stable27-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister to_gif --silent || true
-	docker exec master-stable27-1 sudo -u www-data php occ app_ecosystem_v2:app:register to_gif docker_dev -e --force-scopes \
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister to_gif --silent || true
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register to_gif docker_dev -e --force-scopes \
 		--info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/to_gif/appinfo/info.xml
 
 .PHONY: manual_register27
 manual_register27:
-	docker exec master-stable27-1 sudo -u www-data php occ app_ecosystem_v2:app:unregister to_gif --silent || true
-	docker exec master-stable27-1 sudo -u www-data php occ app_ecosystem_v2:app:register to_gif manual_install --json-info \
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister to_gif --silent || true
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register to_gif manual_install --json-info \
   "{\"appid\":\"to_gif\",\"name\":\"to_gif\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9031,\"scopes\":{\"required\":[\"FILES\", \"NOTIFICATIONS\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
   -e --force-scopes

--- a/nc_py_api/_misc.py
+++ b/nc_py_api/_misc.py
@@ -2,7 +2,8 @@
 
 For internal use, prototypes can change between versions.
 """
-import datetime
+from base64 import b64decode
+from datetime import datetime, timezone
 from random import choice
 from string import ascii_lowercase, ascii_uppercase, digits
 from typing import Callable, Union
@@ -68,9 +69,16 @@ def random_string(size: int) -> str:
     return "".join(choice(letters) for _ in range(size))
 
 
-def nc_iso_time_to_datetime(iso8601_time: str) -> datetime.datetime:
+def nc_iso_time_to_datetime(iso8601_time: str) -> datetime:
     """Returns parsed ``datetime`` or datetime(1970, 1, 1) in case of error."""
     try:
-        return datetime.datetime.fromisoformat(iso8601_time)
+        return datetime.fromisoformat(iso8601_time)
     except (ValueError, TypeError):
-        return datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+        return datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def get_username_secret_from_headers(headers: dict) -> tuple[str, str]:
+    """Returns tuple with ``username`` and ``app_secret`` from headers."""
+    auth_aa = b64decode(headers.get("AUTHORIZATION-APP-API", "")).decode("UTF-8")
+    username, app_secret = auth_aa.split(":", maxsplit=1)
+    return username, app_secret

--- a/nc_py_api/_preferences_ex.py
+++ b/nc_py_api/_preferences_ex.py
@@ -29,7 +29,7 @@ class _BasicAppCfgPref:
         """Returns the value of the key, if found, or the specified default value."""
         if not key:
             raise ValueError("`key` parameter can not be empty")
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         r = self.get_values([key])
         if r:
             return r[0].value
@@ -41,7 +41,7 @@ class _BasicAppCfgPref:
             return []
         if not all(keys):
             raise ValueError("`key` parameter can not be empty")
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         data = {"configKeys": keys}
         results = self._session.ocs(
             method="POST", path=f"{self._session.ae_url}/{self._url_suffix}/get-values", json=data
@@ -56,7 +56,7 @@ class _BasicAppCfgPref:
             return
         if not all(keys):
             raise ValueError("`key` parameter can not be empty")
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         try:
             self._session.ocs(
                 method="DELETE", path=f"{self._session.ae_url}/{self._url_suffix}", json={"configKeys": keys}
@@ -75,7 +75,7 @@ class PreferencesExAPI(_BasicAppCfgPref):
         """Sets a value for a key."""
         if not key:
             raise ValueError("`key` parameter can not be empty")
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         params = {"configKey": key, "configValue": value}
         self._session.ocs(method="POST", path=f"{self._session.ae_url}/{self._url_suffix}", json=params)
 
@@ -94,7 +94,7 @@ class AppConfigExAPI(_BasicAppCfgPref):
         """
         if not key:
             raise ValueError("`key` parameter can not be empty")
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         params: dict = {"configKey": key, "configValue": value}
         if sensitive is not None:
             params["sensitive"] = sensitive

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -109,8 +109,8 @@ class Config(BasicConfig):
 class AppConfig(BasicConfig):
     """Application configuration."""
 
-    ae_version: str
-    """AppEcosystem version"""
+    aa_version: str
+    """AppAPI version"""
     app_name: str
     """Application ID"""
     app_version: str
@@ -120,9 +120,9 @@ class AppConfig(BasicConfig):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.ae_version = self._get_config_value("ae_version", raise_not_found=False, **kwargs)
-        if not self.ae_version:
-            self.ae_version = "1.0.0"
+        self.aa_version = self._get_config_value("aa_version", raise_not_found=False, **kwargs)
+        if not self.aa_version:
+            self.aa_version = "1.0.0"
         self.app_name = self._get_config_value("app_id", **kwargs)
         self.app_version = self._get_config_value("app_version", **kwargs)
         self.app_secret = self._get_config_value("app_secret", **kwargs)
@@ -343,7 +343,7 @@ class NcSessionApp(NcSessionBasic):
         adapter = Client(follow_redirects=True, limits=self.limits, verify=self.cfg.options.nc_cert)
         adapter.headers.update(
             {
-                "AA-VERSION": self.cfg.ae_version,
+                "AA-VERSION": self.cfg.aa_version,
                 "EX-APP-ID": self.cfg.app_name,
                 "EX-APP-VERSION": self.cfg.app_version,
             }

--- a/nc_py_api/_version.py
+++ b/nc_py_api/_version.py
@@ -1,3 +1,3 @@
 """Version of nc_py_api."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0.dev0"

--- a/nc_py_api/apps.py
+++ b/nc_py_api/apps.py
@@ -112,7 +112,7 @@ class _AppsAPI:
         :param enabled: Flag indicating whether to return only enabled applications or all applications.
             Default = **False**.
         """
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         url_param = "enabled" if enabled else "all"
         r = self._session.ocs(method="GET", path=f"{self._session.ae_url}/ex-app/{url_param}")
         return [ExAppInfo(i) for i in r]

--- a/nc_py_api/ex_app/defs.py
+++ b/nc_py_api/ex_app/defs.py
@@ -39,3 +39,5 @@ class ApiScope(enum.IntEnum):
     """Allows access to Talk API endpoints."""
     TALK_BOT = 60
     """Allows to register Talk Bots."""
+    ACTIVITIES = 110
+    """Activity App endpoints."""

--- a/nc_py_api/ex_app/integration_fastapi.py
+++ b/nc_py_api/ex_app/integration_fastapi.py
@@ -8,15 +8,18 @@ import typing
 
 from fastapi import Depends, FastAPI, HTTPException, Request, responses, status
 
+from .._misc import get_username_secret_from_headers
 from ..nextcloud import NextcloudApp
 from ..talk_bot import TalkBotMessage, get_bot_secret
 
 
 def nc_app(request: Request) -> NextcloudApp:
     """Authentication handler for requests from Nextcloud to the application."""
-    user = request.headers.get("NC-USER-ID", "")
-    request_id = request.headers.get("AE-REQUEST-ID", None)
-    headers = {"AE-REQUEST-ID": request_id} if request_id else {}
+    user = get_username_secret_from_headers(
+        {"AUTHORIZATION-APP-API": request.headers.get("AUTHORIZATION-APP-API", "")}
+    )[0]
+    request_id = request.headers.get("AA-REQUEST-ID", None)
+    headers = {"AA-REQUEST-ID": request_id} if request_id else {}
     nextcloud_app = NextcloudApp(user=user, headers=headers)
     if not nextcloud_app.request_sign_check(request):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)

--- a/nc_py_api/ex_app/ui/files.py
+++ b/nc_py_api/ex_app/ui/files.py
@@ -95,7 +95,7 @@ class _UiFilesActionsAPI:
 
     def register(self, name: str, display_name: str, callback_url: str, **kwargs) -> None:
         """Registers the files a dropdown menu element."""
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         params = {
             "fileActionMenuParams": {
                 "name": name,
@@ -112,7 +112,7 @@ class _UiFilesActionsAPI:
 
     def unregister(self, name: str, not_fail=True) -> None:
         """Removes files dropdown menu element."""
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         params = {"fileActionMenuName": name}
         try:
             self._session.ocs(method="DELETE", path=f"{self._session.ae_url}/{self._ep_suffix}", json=params)

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -193,13 +193,13 @@ class NextcloudApp(_NextcloudBasic):
 
     @property
     def app_cfg(self) -> AppConfig:
-        """Returns deploy config, with AppEcosystem version, Application version and name."""
+        """Returns deploy config, with AppAPI version, Application version and name."""
         return self._session.cfg
 
     def register_talk_bot(self, callback_url: str, display_name: str, description: str = "") -> tuple[str, str]:
         """Registers Talk BOT.
 
-        .. note:: AppEcosystem will add a record in a case of successful registration to the ``appconfig_ex`` table.
+        .. note:: AppAPI will add a record in a case of successful registration to the ``appconfig_ex`` table.
 
         :param callback_url: URL suffix for fetching new messages. MUST be ``UNIQ`` for each bot the app provides.
         :param display_name: The name under which the messages will be posted.

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -153,9 +153,9 @@ class NextcloudApp(_NextcloudBasic):
         :param log_lvl: level of the log, content belongs to.
         :param content: string to write into the log.
         """
-        if self.check_capabilities("app_ecosystem_v2"):
+        if self.check_capabilities("app_api"):
             return
-        if int(log_lvl) < self.capabilities["app_ecosystem_v2"].get("loglevel", 0):
+        if int(log_lvl) < self.capabilities["app_api"].get("loglevel", 0):
             return
         self._session.ocs(
             method="POST", path=f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content}
@@ -170,9 +170,9 @@ class NextcloudApp(_NextcloudBasic):
 
         Useful for applications that declare optional scopes to check if they are allowed.
         """
-        if self.check_capabilities("app_ecosystem_v2"):
+        if self.check_capabilities("app_api"):
             return False
-        return scope in self.capabilities["app_ecosystem_v2"]["scopes"]
+        return scope in self.capabilities["app_api"]["scopes"]
 
     @property
     def user(self) -> str:
@@ -206,7 +206,7 @@ class NextcloudApp(_NextcloudBasic):
         :param description: Optional description shown in the admin settings.
         :return: The secret used for signing requests.
         """
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         require_capabilities("spreed.features.bots-v1", self._session.capabilities)
         params = {
             "name": display_name,
@@ -222,7 +222,7 @@ class NextcloudApp(_NextcloudBasic):
         :param callback_url: URL suffix for fetching new messages. MUST be ``UNIQ`` for each bot the app provides.
         :return: The secret used for signing requests.
         """
-        require_capabilities("app_ecosystem_v2", self._session.capabilities)
+        require_capabilities("app_api", self._session.capabilities)
         require_capabilities("spreed.features.bots-v1", self._session.capabilities)
         params = {
             "route": callback_url,

--- a/nc_py_api/notifications.py
+++ b/nc_py_api/notifications.py
@@ -91,16 +91,16 @@ class _NotificationsAPI:
             raise NotImplementedError("Sending notifications is only supported for `App` mode.")
         if not subject:
             raise ValueError("`subject` cannot be empty string.")
-        require_capabilities(["app_ecosystem_v2", "notifications"], self._session.capabilities)
+        require_capabilities(["app_api", "notifications"], self._session.capabilities)
         if subject_params is None:
             subject_params = {}
         if message_params is None:
             message_params = {}
         params: dict = {
             "params": {
-                "object": "app_ecosystem_v2",
+                "object": "app_api",
                 "object_id": random_string(56),
-                "subject_type": "app_ecosystem_v2_ex_app",
+                "subject_type": "app_api_ex_app",
                 "subject_params": {
                     "rich_subject": subject,
                     "rich_subject_params": subject_params,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
 [project.optional-dependencies]
 app = [
   "uvicorn[standard]>=0.23.2",
-  "xxhash>=3.3",
 ]
 bench = [
   "matplotlib",

--- a/scripts/ci_register.sh
+++ b/scripts/ci_register.sh
@@ -3,7 +3,7 @@
 # Parameters:
 # APP_ID, VERSION, SECRET, HOST, PORT
 
-php occ app_ecosystem_v2:daemon:register manual_install "Manual Install" manual-install 0 0 0
-php occ app_ecosystem_v2:app:register "$1" manual_install --json-info \
+php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
+php occ app_api:app:register "$1" manual_install --json-info \
   "{\"appid\":\"$1\",\"name\":\"$1\",\"daemon_config_name\":\"manual_install\",\"version\":\"$2\",\"secret\":\"$3\",\"host\":\"$4\",\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\", \"TALK_BOT\", \"ACTIVITIES\"]},\"port\":$5,\"protocol\":\"http\",\"system_app\":1}" \
   -e --force-scopes

--- a/scripts/dev_register.sh
+++ b/scripts/dev_register.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 echo "removing 'manual_install' deploy daemon for $1 container"
-docker exec "$1" sudo -u www-data php occ app_ecosystem_v2:daemon:unregister manual_install || true
+docker exec "$1" sudo -u www-data php occ app_api:daemon:unregister manual_install || true
 echo "creating 'manual_install' deploy daemon for $1 container"
-docker exec "$1" sudo -u www-data php occ app_ecosystem_v2:daemon:register \
+docker exec "$1" sudo -u www-data php occ app_api:daemon:register \
   manual_install "Manual Install" manual-install 0 0 0
 echo "unregistering nc_py_api as an app for $1 container"
-docker exec "$1" sudo -u www-data php occ app_ecosystem_v2:app:unregister nc_py_api --silent || true
+docker exec "$1" sudo -u www-data php occ app_api:app:unregister nc_py_api --silent || true
 echo "registering nc_py_api as an app for $1 container"
 NEXTCLOUD_URL="http://$2" APP_PORT=9009 APP_ID="nc_py_api" APP_SECRET="12345" APP_VERSION="1.0.0" \
   python3 tests/_install.py > /dev/null 2>&1 &
 echo $! > /tmp/_install.pid
 python3 tests/_install_wait.py "http://localhost:9009/heartbeat" "\"status\":\"ok\"" 15 0.5
-docker exec "$1" sudo -u www-data php occ app_ecosystem_v2:app:register nc_py_api manual_install --json-info \
+docker exec "$1" sudo -u www-data php occ app_api:app:register nc_py_api manual_install --json-info \
   "{\"appid\":\"nc_py_api\",\"name\":\"nc_py_api\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\", \"TALK_BOT\", \"ACTIVITIES\"]},\"port\":9009,\"protocol\":\"http\",\"system_app\":1}" \
   -e --force-scopes
 cat /tmp/_install.pid

--- a/tests/_app_security_checks.py
+++ b/tests/_app_security_checks.py
@@ -1,25 +1,12 @@
-import hmac
-from datetime import datetime, timezone
-from hashlib import sha256
-from json import dumps
+from base64 import b64encode
 from os import environ
 from sys import argv
 
 import requests
-from xxhash import xxh64
 
 
-def sign_request(url: str, req_headers: dict, time: int = 0):
-    data_hash = xxh64()
-    req_headers["AE-DATA-HASH"] = data_hash.hexdigest()
-    if time:
-        req_headers["AE-SIGN-TIME"] = str(time)
-    else:
-        req_headers["AE-SIGN-TIME"] = str(int(datetime.now(timezone.utc).timestamp()))
-    req_headers.pop("AE-SIGNATURE", None)
-    request_to_sign = "PUT" + url + dumps(req_headers, separators=(",", ":"))
-    hmac_sign = hmac.new(environ["APP_SECRET"].encode("UTF-8"), request_to_sign.encode("UTF-8"), digestmod=sha256)
-    req_headers["AE-SIGNATURE"] = hmac_sign.hexdigest()
+def sign_request(req_headers: dict, user: str = ""):
+    req_headers["AUTHORIZATION-APP-API"] = b64encode(f"{user}:{environ['APP_SECRET']}".encode("UTF=8"))
 
 
 # params: app base url
@@ -35,55 +22,36 @@ if __name__ == "__main__":
             "EX-APP-VERSION": environ.get("APP_VERSION", "1.0.0"),
         }
     )
-    sign_request("/sec_check?value=1", headers)
+    sign_request(headers)
     result = requests.put(request_url, headers=headers)
     assert result.status_code == 200
-    # Invalid AE-SIGNATURE
-    request_url = argv[1] + "/sec_check?value=0"
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 401
-    sign_request("/sec_check?value=0", headers)
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 200
-    # Invalid EX-APP-ID
-    old_app_name = headers["EX-APP-ID"]
-    headers["EX-APP-ID"] = "unknown_app"
-    sign_request("/sec_check?value=0", headers)
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 401
-    headers["EX-APP-ID"] = old_app_name
-    sign_request("/sec_check?value=0", headers)
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 200
-    # Invalid AE-DATA-HASH
-    result = requests.put(request_url, headers=headers, data=b"some_data")
-    assert result.status_code == 401
-    # Invalid EX-APP-VERSION
-    sign_request("/sec_check?value=0", headers)
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 200
-    old_version = headers["EX-APP-VERSION"]
-    headers["EX-APP-VERSION"] = "999.0.0"
-    sign_request("/sec_check?value=0", headers)
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 401
-    headers["EX-APP-VERSION"] = old_version
-    sign_request("/sec_check?value=0", headers)
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 200
-    # Sign time
-    sign_request("/sec_check?value=0", headers, time=int(datetime.now(timezone.utc).timestamp()))
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 200
-    sign_request("/sec_check?value=0", headers, time=int(datetime.now(timezone.utc).timestamp() - 4.0 * 60))
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 200
-    sign_request("/sec_check?value=0", headers, time=int(datetime.now(timezone.utc).timestamp() - 5.0 * 60 - 3.0))
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 401
-    sign_request("/sec_check?value=0", headers, time=int(datetime.now(timezone.utc).timestamp() + 4.0 * 60))
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 200
-    sign_request("/sec_check?value=0", headers, time=int(datetime.now(timezone.utc).timestamp() + 5.0 * 60 + 3.0))
-    result = requests.put(request_url, headers=headers)
-    assert result.status_code == 401
+    # # Invalid AA-SIGNATURE
+    # request_url = argv[1] + "/sec_check?value=0"
+    # result = requests.put(request_url, headers=headers)
+    # assert result.status_code == 401
+    # sign_request(headers)
+    # result = requests.put(request_url, headers=headers)
+    # assert result.status_code == 200
+    # # Invalid EX-APP-ID
+    # old_app_name = headers["EX-APP-ID"]
+    # headers["EX-APP-ID"] = "unknown_app"
+    # sign_request(headers)
+    # result = requests.put(request_url, headers=headers)
+    # assert result.status_code == 401
+    # headers["EX-APP-ID"] = old_app_name
+    # sign_request(headers)
+    # result = requests.put(request_url, headers=headers)
+    # assert result.status_code == 200
+    # # Invalid EX-APP-VERSION
+    # sign_request(headers)
+    # result = requests.put(request_url, headers=headers)
+    # assert result.status_code == 200
+    # old_version = headers["EX-APP-VERSION"]
+    # headers["EX-APP-VERSION"] = "999.0.0"
+    # sign_request(headers)
+    # result = requests.put(request_url, headers=headers)
+    # assert result.status_code == 401
+    # headers["EX-APP-VERSION"] = old_version
+    # sign_request(headers)
+    # result = requests.put(request_url, headers=headers)
+    # assert result.status_code == 200

--- a/tests/actual_tests/logs_test.py
+++ b/tests/actual_tests/logs_test.py
@@ -33,12 +33,12 @@ def test_empty_log(nc_app):
 
 
 def test_loglvl_equal(nc_app):
-    current_log_lvl = nc_app.capabilities["app_ecosystem_v2"].get("loglevel", LogLvl.FATAL)
+    current_log_lvl = nc_app.capabilities["app_api"].get("loglevel", LogLvl.FATAL)
     nc_app.log(current_log_lvl, "log should be written")
 
 
 def test_loglvl_less(nc_app):
-    current_log_lvl = nc_app.capabilities["app_ecosystem_v2"].get("loglevel", LogLvl.FATAL)
+    current_log_lvl = nc_app.capabilities["app_api"].get("loglevel", LogLvl.FATAL)
     if current_log_lvl == LogLvl.DEBUG:
         pytest.skip("Log lvl to low")
     with mock.patch("tests.conftest.NC_APP._session._ocs") as _ocs:
@@ -48,11 +48,11 @@ def test_loglvl_less(nc_app):
         assert _ocs.call_count > 0
 
 
-def test_log_without_app_ecosystem_v2(nc_app):
+def test_log_without_app_api(nc_app):
     srv_capabilities = deepcopy(nc_app.capabilities)
     srv_version = deepcopy(nc_app.srv_version)
-    log_lvl = srv_capabilities["app_ecosystem_v2"].pop("loglevel")
-    srv_capabilities.pop("app_ecosystem_v2")
+    log_lvl = srv_capabilities["app_api"].pop("loglevel")
+    srv_capabilities.pop("app_api")
     patched_capabilities = {"capabilities": srv_capabilities, "version": srv_version}
     with (
         mock.patch.dict("tests.conftest.NC_APP._session._capabilities", patched_capabilities, clear=True),

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -28,16 +28,16 @@ def test_nc_exception_to_str():
 
 
 def test_require_capabilities(nc_app):
-    require_capabilities("app_ecosystem_v2", nc_app.capabilities)
-    require_capabilities(["app_ecosystem_v2", "theming"], nc_app.capabilities)
+    require_capabilities("app_api", nc_app.capabilities)
+    require_capabilities(["app_api", "theming"], nc_app.capabilities)
     with pytest.raises(NextcloudException):
         require_capabilities("non_exist_capability", nc_app.capabilities)
     with pytest.raises(NextcloudException):
-        require_capabilities(["non_exist_capability", "app_ecosystem_v2"], nc_app.capabilities)
+        require_capabilities(["non_exist_capability", "app_api"], nc_app.capabilities)
     with pytest.raises(NextcloudException):
-        require_capabilities(["non_exist_capability", "non_exist_capability2", "app_ecosystem_v2"], nc_app.capabilities)
+        require_capabilities(["non_exist_capability", "non_exist_capability2", "app_api"], nc_app.capabilities)
     with pytest.raises(NextcloudException):
-        require_capabilities("app_ecosystem_v2.non_exist_capability", nc_app.capabilities)
+        require_capabilities("app_api.non_exist_capability", nc_app.capabilities)
 
 
 def test_config_get_value():

--- a/tests/actual_tests/nc_app_test.py
+++ b/tests/actual_tests/nc_app_test.py
@@ -20,7 +20,7 @@ def test_app_cfg(nc_app):
     app_cfg = nc_app.app_cfg
     assert app_cfg.app_name == environ["APP_ID"]
     assert app_cfg.app_version == environ["APP_VERSION"]
-    assert app_cfg.app_secret == environ["APP_SECRET"].encode("UTF-8")
+    assert app_cfg.app_secret == environ["APP_SECRET"]
 
 
 def test_scope_allow_app_ecosystem_disabled(nc_client, nc_app):

--- a/tests/actual_tests/nc_app_test.py
+++ b/tests/actual_tests/nc_app_test.py
@@ -25,13 +25,13 @@ def test_app_cfg(nc_app):
 
 def test_scope_allow_app_ecosystem_disabled(nc_client, nc_app):
     assert nc_app.scope_allowed(ApiScope.FILES)
-    nc_client.apps.disable("app_ecosystem_v2")
+    nc_client.apps.disable("app_api")
     try:
         assert nc_app.scope_allowed(ApiScope.FILES)
         nc_app.update_server_info()
         assert not nc_app.scope_allowed(ApiScope.FILES)
     finally:
-        nc_client.apps.enable("app_ecosystem_v2")
+        nc_client.apps.enable("app_api")
         nc_app.update_server_info()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from . import gfixture_set_env  # noqa
 _TEST_FAILED_INCREMENTAL: dict[str, dict[tuple[int, ...], str]] = {}
 
 NC_CLIENT = None if environ.get("SKIP_NC_CLIENT_TESTS", False) else Nextcloud()
-if environ.get("SKIP_AE_TESTS", False):
+if environ.get("SKIP_AA_TESTS", False):
     NC_APP = None
 else:
     NC_APP = NextcloudApp(user="admin")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ if environ.get("SKIP_AE_TESTS", False):
     NC_APP = None
 else:
     NC_APP = NextcloudApp(user="admin")
-    if "app_ecosystem_v2" not in NC_APP.capabilities:
+    if "app_api" not in NC_APP.capabilities:
         NC_APP = None
 if NC_CLIENT is None and NC_APP is None:
     raise EnvironmentError("Tests require at least Nextcloud or NextcloudApp.")

--- a/tests/gfixture_set_env.py
+++ b/tests/gfixture_set_env.py
@@ -3,7 +3,7 @@ from os import environ
 if not environ.get("CI", False):  # For local tests
     environ["NC_AUTH_USER"] = "admin"
     environ["NC_AUTH_PASS"] = "admin"  # "MrtGY-KfY24-iiDyg-cr4n4-GLsNZ"
-    environ["NEXTCLOUD_URL"] = environ.get("NEXTCLOUD_URL", "http://nextcloud.local")
+    environ["NEXTCLOUD_URL"] = environ.get("NEXTCLOUD_URL", "http://stable27.local")
     environ["APP_ID"] = "nc_py_api"
     environ["APP_VERSION"] = "1.0.0"
     environ["APP_SECRET"] = "12345"


### PR DESCRIPTION
It was decided to change the name of App Ecosystem to AppAPI before its first release at the end of September.
It was also decided to make authentication as simple as possible, and for remotely running applications, transport layer encryption should always be used.


This is draft, waiting for AppAPI to be updated with rewritten new auth to make benches.