### PR TITLE
implemented chunked file upload v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2 - 2023-09-2x]
+
+### Added
+
+- FilesAPI: [Chunked v2 upload](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/chunking.html#chunked-upload-v2) support, enabled by default.
+- New option to disable `chunked v2 upload` if there is need for that: `CHUNKED_UPLOAD_V2`
+
+### Changed
+
+- Default `chunk_size` argument is now 5Mb instead of 4Mb.
+
 ## [0.2.1 - 2023-09-14]
 
 ### Added

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -55,12 +55,14 @@ class RuntimeOptions:
     timeout: Optional[int]
     timeout_dav: Optional[int]
     _nc_cert: Union[str, bool]
+    upload_chunk_v2: bool
 
     def __init__(self, **kwargs):
         self.xdebug_session = kwargs.get("xdebug_session", options.XDEBUG_SESSION)
         self.timeout = kwargs.get("npa_timeout", options.NPA_TIMEOUT)
         self.timeout_dav = kwargs.get("npa_timeout_dav", options.NPA_TIMEOUT_DAV)
         self._nc_cert = kwargs.get("npa_nc_cert", options.NPA_NC_CERT)
+        self.upload_chunk_v2 = kwargs.get("chunked_upload_v2", options.CHUNKED_UPLOAD_V2)
 
     @property
     def nc_cert(self) -> Union[str, bool]:

--- a/nc_py_api/options.py
+++ b/nc_py_api/options.py
@@ -38,3 +38,10 @@ if str_val.lower() in ("false", "0"):
     NPA_NC_CERT = False
 elif str_val.lower() not in ("true", "1"):
     NPA_NC_CERT = str_val
+
+CHUNKED_UPLOAD_V2 = True
+"""Option to enable/disable **version 2** chunked upload(better Object Storages support).
+
+Additional information can be found in Nextcloud documentation:
+`Chunked file upload V2
+<https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/chunking.html#chunked-upload-v2>`_"""

--- a/tests/actual_tests/files_test.py
+++ b/tests/actual_tests/files_test.py
@@ -201,6 +201,15 @@ def test_file_upload_file(nc_any):
     assert nc_any.files.download("test_dir_tmp/test_file_upload_file") == content
 
 
+def test_file_upload_chunked_v2(nc_any):
+    with NamedTemporaryFile() as tmp_file:
+        tmp_file.seek(7 * 1024 * 1024)
+        tmp_file.write(b"\0")
+        tmp_file.flush()
+        nc_any.files.upload_stream("test_dir_tmp/test_file_upload_chunked_v2", tmp_file.name)
+    assert len(nc_any.files.download("test_dir_tmp/test_file_upload_chunked_v2")) == 7 * 1024 * 1024 + 1
+
+
 @pytest.mark.parametrize("file_name", ("chunked_zero", "chunked_zero/", "chunked_zero//"))
 def test_file_upload_chunked_zero_size(nc_any, file_name):
     nc_any.files.delete("/test_dir_tmp/test_file_upload_del", not_fail=True)

--- a/tests/actual_tests/options_test.py
+++ b/tests/actual_tests/options_test.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from subprocess import PIPE, run
+from unittest import mock
 
 import nc_py_api
 
@@ -51,3 +52,20 @@ def test_xdebug_session(nc_any):
     nc_py_api.options.XDEBUG_SESSION = "12345"
     new_nc = nc_py_api.Nextcloud() if isinstance(nc_any, nc_py_api.Nextcloud) else nc_py_api.NextcloudApp()
     assert new_nc._session.adapter.cookies["XDEBUG_SESSION"] == "12345"
+
+
+@mock.patch("nc_py_api.options.CHUNKED_UPLOAD_V2", False)
+def test_chunked_upload(nc_any):
+    new_nc = nc_py_api.Nextcloud() if isinstance(nc_any, nc_py_api.Nextcloud) else nc_py_api.NextcloudApp()
+    assert new_nc._session.cfg.options.upload_chunk_v2 is False
+
+
+def test_chunked_upload2(nc_any):
+    new_nc = (
+        nc_py_api.Nextcloud(chunked_upload_v2=False)
+        if isinstance(nc_any, nc_py_api.Nextcloud)
+        else nc_py_api.NextcloudApp(chunked_upload_v2=False)
+    )
+    assert new_nc._session.cfg.options.upload_chunk_v2 is False
+    new_nc = nc_py_api.Nextcloud() if isinstance(nc_any, nc_py_api.Nextcloud) else nc_py_api.NextcloudApp()
+    assert new_nc._session.cfg.options.upload_chunk_v2 is True


### PR DESCRIPTION
There are two versions of the chunking API. Version 1 is the original version and version 2 was built as a backward compatible extension to support uploads directly to supporting target storages like S3. Version 2 is the recommended version to use.

---

https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/chunking.html