### PR TITLE
reworked `users.get_details`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0 - 2023-10-2x]
+
+This release contains some breaking changes in `users` API.
+
+### Changed
+
+- `users.get_details` renamed to `get_user` and returns a class instead of a dictionary.
+- Optional argument `displayname` in `users.create` renamed to `display_name`.
+
+### Fixed
+
+- `users.get_details` with empty parameter in some cases was raised exception.
+
 ## [0.3.1 - 2023-10-07]
 
 ### Added

--- a/docs/reference/Users/Users.rst
+++ b/docs/reference/Users/Users.rst
@@ -1,5 +1,8 @@
 User Management
 ---------------
 
+.. autoclass:: nc_py_api.users.UserInfo
+    :members:
+
 .. autoclass:: nc_py_api.users._UsersAPI
     :members:

--- a/nc_py_api/_version.py
+++ b/nc_py_api/_version.py
@@ -1,3 +1,3 @@
 """Version of nc_py_api."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0.dev0"

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -60,7 +60,7 @@ class UserInfo:
     @property
     def email(self) -> str:
         """Email address of the user."""
-        return self._raw_data["email"]
+        return self._raw_data["email"] if self._raw_data["email"] is not None else ""
 
     @property
     def additional_mail(self) -> list[str]:
@@ -138,13 +138,13 @@ class UserInfo:
         return self._raw_data.get("locale", "")
 
     @property
-    def notify_email(self) -> typing.Optional[str]:
+    def notify_email(self) -> str:
         """The user's preferred email address.
 
         .. note:: The primary mail address may be set be the user to specify a different
             email address where mails by Nextcloud are sent to. It is not necessarily set.
         """
-        return self._raw_data["notify_email"]
+        return self._raw_data["notify_email"] if self._raw_data["notify_email"] is not None else ""
 
     @property
     def backend_capabilities(self) -> dict:

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -70,7 +70,7 @@ class UserInfo:
     @property
     def display_name(self) -> str:
         """The display name of the new user."""
-        return self._raw_data.get("displayname", "")
+        return self._raw_data["displayname"] if "displayname" in self._raw_data else self._raw_data["display-name"]
 
     @property
     def phone(self) -> str:

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -70,7 +70,7 @@ class UserInfo:
     @property
     def display_name(self) -> str:
         """The display name of the new user."""
-        return self._raw_data["displayname"]
+        return self._raw_data.get("displayname", "")
 
     @property
     def phone(self) -> str:

--- a/tests/actual_tests/conftest.py
+++ b/tests/actual_tests/conftest.py
@@ -105,6 +105,7 @@ def tear_up_down(nc_any, rand_bytes):
             environ["TEST_USER_ID"],
             password=environ["TEST_USER_PASS"],
             groups=[environ["TEST_GROUP_BOTH"], environ["TEST_GROUP_USER"]],
+            display_name=environ["TEST_USER_ID"],
         )
     init_filesystem_for_user(nc_any, rand_bytes)  # currently we initialize filesystem only for admin
 

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -60,7 +60,7 @@ def test_deffered_error():
 
 def test_ocs_response_headers(nc):
     old_headers = nc.response_headers
-    nc.users.get_details()
+    nc.users.get_user()
     assert old_headers != nc.response_headers
 
 

--- a/tests/actual_tests/users_test.py
+++ b/tests/actual_tests/users_test.py
@@ -33,6 +33,7 @@ def test_get_user_info(nc):
         "biography",
         "language",
         "locale",
+        "notify_email",
     ):
         assert getattr(current_user, i) == getattr(admin, i)
         assert isinstance(getattr(current_user, i), str)
@@ -47,7 +48,6 @@ def test_get_user_info(nc):
     assert isinstance(admin.quota, dict)
     assert isinstance(admin.additional_mail, list)
     assert isinstance(admin.groups, list)
-    assert isinstance(admin.notify_email, str) or admin.notify_email is None
     assert isinstance(admin.backend_capabilities, dict)
 
 

--- a/tests/actual_tests/users_test.py
+++ b/tests/actual_tests/users_test.py
@@ -97,7 +97,7 @@ def test_delete_user(nc_client):
         nc_client.users.delete(test_user_name)
 
 
-def test_users_get_list(nc):
+def test_users_get_list(nc, nc_client):
     users = nc.users.get_list()
     assert isinstance(users, list)
     assert nc.user in users

--- a/tests/actual_tests/users_test.py
+++ b/tests/actual_tests/users_test.py
@@ -49,6 +49,7 @@ def test_get_user_info(nc):
     assert isinstance(admin.additional_mail, list)
     assert isinstance(admin.groups, list)
     assert isinstance(admin.backend_capabilities, dict)
+    assert admin.display_name == "admin"
 
 
 def test_get_current_user_wo_user(nc):

--- a/tests/actual_tests/users_test.py
+++ b/tests/actual_tests/users_test.py
@@ -1,34 +1,72 @@
 import contextlib
+import datetime
 from os import environ
 
 import pytest
 
-from nc_py_api import NextcloudException, NextcloudExceptionNotFound
+from nc_py_api import (
+    NextcloudApp,
+    NextcloudException,
+    NextcloudExceptionNotFound,
+    users,
+)
 
 
-def test_get_user_details(nc):
-    admin = nc.users.get_details("admin")
-    assert admin
-    current_user = nc.users.get_details()
-    assert current_user
-    admin.pop("quota", None)  # `quota` is a little bit different
-    current_user.pop("quota", None)
-    assert admin == current_user
+def test_get_user_info(nc):
+    admin = nc.users.get_user("admin")
+    current_user = nc.users.get_user()
+    for i in (
+        "user_id",
+        "email",
+        "display_name",
+        "storage_location",
+        "backend",
+        "manager",
+        "phone",
+        "address",
+        "website",
+        "twitter",
+        "fediverse",
+        "organisation",
+        "role",
+        "headline",
+        "biography",
+        "language",
+        "locale",
+    ):
+        assert getattr(current_user, i) == getattr(admin, i)
+        assert isinstance(getattr(current_user, i), str)
+        assert isinstance(getattr(admin, i), str)
+    assert admin.enabled is True
+    assert admin.enabled == current_user.enabled
+    assert admin.profile_enabled is True
+    assert admin.profile_enabled == current_user.profile_enabled
+    assert isinstance(admin.last_login, datetime.datetime)
+    assert isinstance(current_user.last_login, datetime.datetime)
+    assert isinstance(admin.subadmin, list)
+    assert isinstance(admin.quota, dict)
+    assert isinstance(admin.additional_mail, list)
+    assert isinstance(admin.groups, list)
+    assert isinstance(admin.notify_email, str) or admin.notify_email is None
+    assert isinstance(admin.backend_capabilities, dict)
 
 
 def test_get_current_user_wo_user(nc):
     orig_user = nc._session.user
     try:
         nc._session.user = ""
-        with pytest.raises(ValueError):
-            nc.users.get_details()
+        if isinstance(nc, NextcloudApp):
+            with pytest.raises(NextcloudException):
+                nc.users.get_user()
+        else:
+            assert isinstance(nc.users.get_user(), users.UserInfo)
     finally:
         nc._session.user = orig_user
 
 
 def test_get_user_404(nc):
     with pytest.raises(NextcloudException):
-        nc.users.get_details("non existing user")
+        nc.users.get_user("non existing user")
 
 
 def test_create_user_with_groups(nc_client):
@@ -58,16 +96,16 @@ def test_delete_user(nc_client):
         nc_client.users.delete(test_user_name)
 
 
-def test_users_get_list(nc_client):
-    users = nc_client.users.get_list()
+def test_users_get_list(nc):
+    users = nc.users.get_list()
     assert isinstance(users, list)
-    assert nc_client.user in users
+    assert nc.user in users
     assert environ["TEST_ADMIN_ID"] in users
     assert environ["TEST_USER_ID"] in users
-    users = nc_client.users.get_list(limit=1)
+    users = nc.users.get_list(limit=1)
     assert len(users) == 1
-    assert users[0] != nc_client.users.get_list(limit=1, offset=1)[0]
-    users = nc_client.users.get_list(mask=environ["TEST_ADMIN_ID"])
+    assert users[0] != nc.users.get_list(limit=1, offset=1)[0]
+    users = nc.users.get_list(mask=environ["TEST_ADMIN_ID"])
     assert len(users) == 1
 
 
@@ -76,27 +114,27 @@ def test_enable_disable_user(nc_client):
     with contextlib.suppress(NextcloudException):
         nc_client.users.create(test_user_name, password="az1dcaNG4c42")
     nc_client.users.disable(test_user_name)
-    assert not nc_client.users.get_details(test_user_name)["enabled"]
+    assert nc_client.users.get_user(test_user_name).enabled is False
     nc_client.users.enable(test_user_name)
-    assert nc_client.users.get_details(test_user_name)["enabled"]
+    assert nc_client.users.get_user(test_user_name).enabled is True
     nc_client.users.delete(test_user_name)
 
 
-def test_user_editable_fields(nc_client):
-    editable_fields = nc_client.users.editable_fields()
+def test_user_editable_fields(nc):
+    editable_fields = nc.users.editable_fields()
     assert isinstance(editable_fields, list)
     assert editable_fields
 
 
 def test_edit_user(nc_client):
     nc_client.users.edit(nc_client.user, address="Le Pame", email="admino@gmx.net")
-    current_user = nc_client.users.get_details()
-    assert current_user["address"] == "Le Pame"
-    assert current_user["email"] == "admino@gmx.net"
+    current_user = nc_client.users.get_user()
+    assert current_user.address == "Le Pame"
+    assert current_user.email == "admino@gmx.net"
     nc_client.users.edit(nc_client.user, address="", email="admin@gmx.net")
-    current_user = nc_client.users.get_details()
-    assert current_user["address"] == ""
-    assert current_user["email"] == "admin@gmx.net"
+    current_user = nc_client.users.get_user()
+    assert current_user.address == ""
+    assert current_user.email == "admin@gmx.net"
 
 
 def test_resend_user_email(nc_client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def nc_any() -> Union[Nextcloud, NextcloudApp]:
 
 
 @pytest.fixture(scope="session")
-def nc(request):
+def nc(request) -> Union[Nextcloud, NextcloudApp]:
     """Marks a test to run for both modes if possible."""
     return request.param
 


### PR DESCRIPTION
Changes proposed in this pull request:

 * `users.get_details` renamed to `get_user` and returns a class instead of a dictionary.
 * Optional argument `displayname` in `users.create` renamed to `display_name`.
 
 ## Fixed:
 
 * `users.get_details` with empty parameter in some cases was raised exception.
