### PR TITLE
Client mode: LDAP user_id bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This release contains some breaking changes in `users`, `notifications` API.
 
 ### Added
 
-- `__repr__` method added for most objects(previously it was only present for `FsNode`).
+- `__repr__` method added for most objects(previously it was only present for `FsNode`). #147
 
 ### Changed
 
@@ -21,6 +21,7 @@ This release contains some breaking changes in `users`, `notifications` API.
 ### Fixed
 
 - `users.get_details` with empty parameter in some cases was raised exception.
+- ClientMode: in case when LDAP was used as user backend, user login differs from user_id and most API failed with 404. #148
 
 ## [0.3.1 - 2023-10-07]
 

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -423,7 +423,7 @@ class NcSessionApp(NcSessionBasic):
         return adapter
 
     def sign_request(self, headers: dict) -> None:
-        headers["AUTHORIZATION-APP-API"] = b64encode(f"{self.user}:{self.cfg.app_secret}".encode("UTF=8"))
+        headers["AUTHORIZATION-APP-API"] = b64encode(f"{self._user}:{self.cfg.app_secret}".encode("UTF=8"))
 
     def sign_check(self, request: Request) -> None:
         headers = {

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -332,8 +332,8 @@ class NcSessionBasic(ABC):
 
     @property
     def user(self) -> str:
-        """Current user ID. Can be different from login name."""
-        if not self._user and isinstance(self, NcSession):  # do not trigger for NextcloudApp
+        """Current user ID. Can be different from the login name."""
+        if isinstance(self, NcSession) and not self._user:  # do not trigger for NextcloudApp
             self._user = self.ocs(method="GET", path="/ocs/v1.php/cloud/user")["id"]
         return self._user
 

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -333,7 +333,7 @@ class NcSessionBasic(ABC):
     @property
     def user(self) -> str:
         """Current user ID. Can be different from login name."""
-        if not self._user:
+        if not self._user and isinstance(self, NcSession):  # do not trigger for NextcloudApp
             self._user = self.ocs(method="GET", path="/ocs/v1.php/cloud/user")["id"]
         return self._user
 

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -122,7 +122,7 @@ class Nextcloud(_NextcloudBasic):
 
     @property
     def user(self) -> str:
-        """Returns current user name."""
+        """Returns current user ID."""
         return self._session.user
 
 
@@ -184,7 +184,7 @@ class NextcloudApp(_NextcloudBasic):
 
     @property
     def user(self) -> str:
-        """Property containing the current username.
+        """Property containing the current user ID.
 
         *System Applications* can set it and impersonate the user. For normal applications, it is set automatically.
         """

--- a/tests/actual_tests/user_status_test.py
+++ b/tests/actual_tests/user_status_test.py
@@ -106,14 +106,14 @@ def test_set_predefined(nc, clear_at):
 
 
 @pytest.mark.require_nc(major=27)
-def test_get_back_status_from_from_empty_user(nc):
-    orig_user = nc._session.user
-    nc._session.user = ""
+def test_get_back_status_from_from_empty_user(nc_app):
+    orig_user = nc_app._session.user
+    nc_app._session.user = ""
     try:
         with pytest.raises(ValueError):
-            nc.user_status.get_backup_status("")
+            nc_app.user_status.get_backup_status("")
     finally:
-        nc._session.user = orig_user
+        nc_app._session.user = orig_user
 
 
 @pytest.mark.require_nc(major=27)


### PR DESCRIPTION
By default, the login passed to the Nextcloud class was taken as the user name.

If a backend other than the Database is used, these two values do not match each other, that is, the login can be:
"milena.kvitkova@domain.com", and the user ID for making API requests will be: "milena"

Note: This bug does not apply to the NextcloudApp class, because there the AppAPI transmits the user ID, and not the user login - this only affects use as a client.