### PR TITLE
sign AppAPI requests with `update` method to support `httpx.Headers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1 - 2023-11-xx]
+
+### Fixed
+
+- `headers` can now be `httpx.Headers` and not only `dict`. #158
+
 ## [0.5.0 - 2023-10-23]
 
 ### Added

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -424,7 +424,7 @@ class NcSessionApp(NcSessionBasic):
         return adapter
 
     def sign_request(self, headers: dict) -> None:
-        headers["AUTHORIZATION-APP-API"] = b64encode(f"{self._user}:{self.cfg.app_secret}".encode("UTF=8"))
+        headers.update({"AUTHORIZATION-APP-API": b64encode(f"{self._user}:{self.cfg.app_secret}".encode("UTF=8"))})
 
     def sign_check(self, request: Request) -> None:
         headers = {


### PR DESCRIPTION
Probably this will fix tests from #157 
