### PR TITLE
Clean-up/Refactoring of old code

### DIFF
--- a/nc_py_api/_preferences.py
+++ b/nc_py_api/_preferences.py
@@ -20,9 +20,9 @@ class PreferencesAPI:
     def set_value(self, app_name: str, key: str, value: str) -> None:
         """Sets the value for the key for the specific application."""
         require_capabilities("provisioning_api", self._session.capabilities)
-        self._session.ocs(method="POST", path=f"{self._ep_base}/{app_name}/{key}", params={"configValue": value})
+        self._session.ocs("POST", f"{self._ep_base}/{app_name}/{key}", params={"configValue": value})
 
     def delete(self, app_name: str, key: str) -> None:
         """Removes a key and its value for a specific application."""
         require_capabilities("provisioning_api", self._session.capabilities)
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/{app_name}/{key}")
+        self._session.ocs("DELETE", f"{self._ep_base}/{app_name}/{key}")

--- a/nc_py_api/_preferences_ex.py
+++ b/nc_py_api/_preferences_ex.py
@@ -44,9 +44,7 @@ class _BasicAppCfgPref:
             raise ValueError("`key` parameter can not be empty")
         require_capabilities("app_api", self._session.capabilities)
         data = {"configKeys": keys}
-        results = self._session.ocs(
-            method="POST", path=f"{self._session.ae_url}/{self._url_suffix}/get-values", json=data
-        )
+        results = self._session.ocs("POST", f"{self._session.ae_url}/{self._url_suffix}/get-values", json=data)
         return [CfgRecord(i) for i in results]
 
     def delete(self, keys: typing.Union[str, list[str]], not_fail=True) -> None:
@@ -59,9 +57,7 @@ class _BasicAppCfgPref:
             raise ValueError("`key` parameter can not be empty")
         require_capabilities("app_api", self._session.capabilities)
         try:
-            self._session.ocs(
-                method="DELETE", path=f"{self._session.ae_url}/{self._url_suffix}", json={"configKeys": keys}
-            )
+            self._session.ocs("DELETE", f"{self._session.ae_url}/{self._url_suffix}", json={"configKeys": keys})
         except NextcloudExceptionNotFound as e:
             if not not_fail:
                 raise e from None
@@ -78,7 +74,7 @@ class PreferencesExAPI(_BasicAppCfgPref):
             raise ValueError("`key` parameter can not be empty")
         require_capabilities("app_api", self._session.capabilities)
         params = {"configKey": key, "configValue": value}
-        self._session.ocs(method="POST", path=f"{self._session.ae_url}/{self._url_suffix}", json=params)
+        self._session.ocs("POST", f"{self._session.ae_url}/{self._url_suffix}", json=params)
 
 
 class AppConfigExAPI(_BasicAppCfgPref):
@@ -99,4 +95,4 @@ class AppConfigExAPI(_BasicAppCfgPref):
         params: dict = {"configKey": key, "configValue": value}
         if sensitive is not None:
             params["sensitive"] = sensitive
-        self._session.ocs(method="POST", path=f"{self._session.ae_url}/{self._url_suffix}", json=params)
+        self._session.ocs("POST", f"{self._session.ae_url}/{self._url_suffix}", json=params)

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -176,7 +176,6 @@ class NcSessionBasic(ABC):
         self.init_adapter()
         info = f"request: method={method}, path_params={path_params}"
         nested_req = kwargs.pop("nested_req", False)
-        not_parse = kwargs.pop("not_parse", False)
         try:
             timeout = kwargs.pop("timeout", self.cfg.options.timeout)
             response = self.adapter.request(
@@ -186,8 +185,6 @@ class NcSessionBasic(ABC):
             raise NextcloudException(408, info=info) from None
 
         check_error(response.status_code, info)
-        if not_parse:
-            return response
         response_data = loads(response.text)
         ocs_meta = response_data["ocs"]["meta"]
         if ocs_meta["status"] != "ok":

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -184,7 +184,7 @@ class NcSessionBasic(ABC):
         except ReadTimeout:
             raise NextcloudException(408, info=info) from None
 
-        check_error(response.status_code, info)
+        check_error(response, info)
         response_data = loads(response.text)
         ocs_meta = response_data["ocs"]["meta"]
         if ocs_meta["status"] != "ok":

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -259,15 +259,15 @@ class NcSessionBasic(ABC):
             return {
                 "base_url": self.cfg.dav_endpoint,
                 "timeout": self.cfg.options.timeout_dav,
-                "event_hooks": {"request": [self._request_event], "response": [self._response_event]},
+                "event_hooks": {"request": [], "response": [self._response_event]},
             }
         return {
             "base_url": self.cfg.endpoint,
             "timeout": self.cfg.options.timeout,
-            "event_hooks": {"request": [self._request_event], "response": [self._response_event]},
+            "event_hooks": {"request": [self._request_event_ocs], "response": [self._response_event]},
         }
 
-    def _request_event(self, request: Request) -> None:
+    def _request_event_ocs(self, request: Request) -> None:
         str_url = str(request.url)
         if re.search(self.__ocs_regexp, str_url) is not None:  # this is OCS call
             request.url = request.url.copy_merge_params({"format": "json"})

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -134,7 +134,6 @@ class NcSessionBasic(ABC):
     cfg: BasicConfig
     custom_headers: dict
     response_headers: Headers
-    response_headers_dav: Headers
     _user: str
     _capabilities: dict
 
@@ -147,7 +146,6 @@ class NcSessionBasic(ABC):
         self.init_adapter()
         self.init_adapter_dav()
         self.response_headers = Headers()
-        self.response_headers_dav = Headers()
 
     def __del__(self):
         if hasattr(self, "adapter") and self.adapter:
@@ -283,7 +281,7 @@ class NcSessionBasic(ABC):
             return {
                 "base_url": self.cfg.dav_endpoint,
                 "timeout": self.cfg.options.timeout_dav,
-                "event_hooks": {"response": [self._response_event_dav]},
+                "event_hooks": {"response": [self._response_event]},
             }
         return {
             "base_url": self.cfg.endpoint,
@@ -298,9 +296,6 @@ class NcSessionBasic(ABC):
             if str_url.endswith(i):
                 return
         self.response_headers = response.headers
-
-    def _response_event_dav(self, response: Response):
-        self.response_headers_dav = response.headers
 
 
 class NcSession(NcSessionBasic):

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -3,7 +3,6 @@
 import typing
 from abc import ABC, abstractmethod
 from base64 import b64encode
-from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import IntEnum
 from json import dumps, loads
@@ -257,15 +256,6 @@ class NcSessionBasic(ABC):
             **kwargs,
         )
 
-    def dav_stream(
-        self, method: str, path: str, data: Optional[Union[str, bytes]] = None, **kwargs
-    ) -> Iterator[Response]:
-        headers = kwargs.pop("headers", {})
-        data_bytes = None
-        if data is not None:
-            data_bytes = data.encode("UTF-8") if isinstance(data, str) else data
-        return self._dav_stream(method, quote(path), headers, data_bytes, **kwargs)
-
     def _dav(self, method: str, path: str, headers: dict, data: Optional[bytes], **kwargs) -> Response:
         self.init_adapter_dav()
         timeout = kwargs.pop("timeout", self.cfg.options.timeout_dav)
@@ -279,11 +269,6 @@ class NcSessionBasic(ABC):
         )
         self.response_headers = result.headers
         return result
-
-    def _dav_stream(self, method: str, path: str, headers: dict, data: Optional[bytes], **kwargs) -> Iterator[Response]:
-        self.init_adapter_dav()
-        timeout = kwargs.pop("timeout", self.cfg.options.timeout_dav)
-        return self.adapter_dav.stream(method, path, headers=headers, content=data, timeout=timeout, **kwargs)
 
     def init_adapter(self, restart=False) -> None:
         if getattr(self, "adapter", None) is None or restart:

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -396,33 +396,15 @@ class NcSessionApp(NcSessionBasic):
         self.cfg = AppConfig(**kwargs)
         super().__init__(**kwargs)
 
-    def _get_stream(self, path_params: str, headers: dict, **kwargs) -> Iterator[Response]:
-        self.sign_request(headers)
-        return super()._get_stream(path_params, headers, **kwargs)
-
-    def _ocs(self, method: str, path_params: str, headers: dict, data: Optional[bytes], **kwargs):
-        self.sign_request(headers)
-        return super()._ocs(method, path_params, headers, data, **kwargs)
-
-    def _dav(self, method: str, path: str, headers: dict, data: Optional[bytes], **kwargs) -> Response:
-        self.sign_request(headers)
-        return super()._dav(method, path, headers, data, **kwargs)
-
-    def _dav_stream(self, method: str, path: str, headers: dict, data: Optional[bytes], **kwargs) -> Iterator[Response]:
-        self.sign_request(headers)
-        return super()._dav_stream(method, path, headers, data, **kwargs)
-
     def _create_adapter(self) -> Client:
         adapter = Client(follow_redirects=True, limits=self.limits, verify=self.cfg.options.nc_cert)
         adapter.headers.update({
             "AA-VERSION": self.cfg.aa_version,
             "EX-APP-ID": self.cfg.app_name,
             "EX-APP-VERSION": self.cfg.app_version,
+            "AUTHORIZATION-APP-API": b64encode(f"{self._user}:{self.cfg.app_secret}".encode("UTF=8")),
         })
         return adapter
-
-    def sign_request(self, headers: dict) -> None:
-        headers.update({"AUTHORIZATION-APP-API": b64encode(f"{self._user}:{self.cfg.app_secret}".encode("UTF=8"))})
 
     def sign_check(self, request: Request) -> None:
         headers = {

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -251,7 +251,7 @@ class NcSessionBasic(ABC):
         data_bytes = self.__data_to_bytes(headers, data, json)
         return self._dav(
             method,
-            quote(self.cfg.dav_url_suffix + path) if isinstance(path, str) else path,
+            quote(path) if isinstance(path, str) else path,
             headers,
             data_bytes,
             **kwargs,
@@ -264,7 +264,7 @@ class NcSessionBasic(ABC):
         data_bytes = None
         if data is not None:
             data_bytes = data.encode("UTF-8") if isinstance(data, str) else data
-        return self._dav_stream(method, quote(self.cfg.dav_url_suffix + path), headers, data_bytes, **kwargs)
+        return self._dav_stream(method, quote(path), headers, data_bytes, **kwargs)
 
     def _dav(self, method: str, path: str, headers: dict, data: Optional[bytes], **kwargs) -> Response:
         self.init_adapter_dav()
@@ -374,7 +374,7 @@ class NcSession(NcSessionBasic):
             follow_redirects=True,
             limits=self.limits,
             verify=self.cfg.options.nc_cert,
-            base_url=self.cfg.endpoint,
+            base_url=self.cfg.endpoint + self.cfg.dav_url_suffix if dav else self.cfg.endpoint,
             timeout=self.cfg.options.timeout_dav if dav else self.cfg.options.timeout,
         )
 
@@ -392,7 +392,7 @@ class NcSessionApp(NcSessionBasic):
             limits=self.limits,
             verify=self.cfg.options.nc_cert,
             event_hooks={"request": [self._add_auth]},
-            base_url=self.cfg.endpoint,
+            base_url=self.cfg.endpoint + self.cfg.dav_url_suffix if dav else self.cfg.endpoint,
             timeout=self.cfg.options.timeout_dav if dav else self.cfg.options.timeout,
         )
         adapter.headers.update({

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -321,7 +321,6 @@ class NcSessionApp(NcSessionBasic):
         )
 
     def _add_auth(self, request: Request):
-        # request.url.copy_add_param()
         request.headers.update({
             "AUTHORIZATION-APP-API": b64encode(f"{self._user}:{self.cfg.app_secret}".encode("UTF=8"))
         })

--- a/nc_py_api/_talk_api.py
+++ b/nc_py_api/_talk_api.py
@@ -545,7 +545,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         ep_suffix = "/dark" if dark else ""
         response = self._session.adapter.get(self._ep_base + f"/api/v1/room/{token}/avatar" + ep_suffix)
-        check_error(response.status_code)
+        check_error(response)
         return response.content
 
     @staticmethod

--- a/nc_py_api/_talk_api.py
+++ b/nc_py_api/_talk_api.py
@@ -3,6 +3,7 @@
 import hashlib
 import typing
 
+from ._exceptions import check_error
 from ._misc import (
     check_capabilities,
     clear_from_params_empty,
@@ -543,7 +544,8 @@ class _TalkAPI:
         require_capabilities("spreed.features.avatar", self._session.capabilities)
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         ep_suffix = "/dark" if dark else ""
-        response = self._session.ocs("GET", self._ep_base + f"/api/v1/room/{token}/avatar" + ep_suffix, not_parse=True)
+        response = self._session.adapter.get(self._ep_base + f"/api/v1/room/{token}/avatar" + ep_suffix)
+        check_error(response.status_code)
         return response.content
 
     @staticmethod

--- a/nc_py_api/_talk_api.py
+++ b/nc_py_api/_talk_api.py
@@ -167,7 +167,7 @@ class _TalkAPI:
         .. note:: Password should match the password policy.
         """
         token = conversation.token if isinstance(conversation, Conversation) else conversation
-        self._session.ocs("PUT", self._ep_base + f"/api/v4/room/{token}/password", {"password": password})
+        self._session.ocs("PUT", self._ep_base + f"/api/v4/room/{token}/password", params={"password": password})
 
     def set_conversation_readonly(self, conversation: typing.Union[Conversation, str], read_only: bool) -> None:
         """Changes conversation **read_only** state.
@@ -176,7 +176,7 @@ class _TalkAPI:
         :param read_only: value to set for the ``read_only`` state.
         """
         token = conversation.token if isinstance(conversation, Conversation) else conversation
-        self._session.ocs("PUT", self._ep_base + f"/api/v4/room/{token}/read-only", {"state": int(read_only)})
+        self._session.ocs("PUT", self._ep_base + f"/api/v4/room/{token}/read-only", params={"state": int(read_only)})
 
     def set_conversation_public(self, conversation: typing.Union[Conversation, str], public: bool) -> None:
         """Changes conversation **public** state.
@@ -196,7 +196,7 @@ class _TalkAPI:
         :param new_lvl: new value for notification level for the current user.
         """
         token = conversation.token if isinstance(conversation, Conversation) else conversation
-        self._session.ocs("POST", self._ep_base + f"/api/v4/room/{token}/notify", {"level": int(new_lvl)})
+        self._session.ocs("POST", self._ep_base + f"/api/v4/room/{token}/notify", json={"level": int(new_lvl)})
 
     def get_conversation_by_token(self, conversation: typing.Union[Conversation, str]) -> Conversation:
         """Gets conversation by token."""

--- a/nc_py_api/activity.py
+++ b/nc_py_api/activity.py
@@ -112,7 +112,7 @@ class Activity:
         .. note:: They are stored in objects as key-value pairs of the object_id and the object_name:
             { object_id: object_name}
         """
-        return self._raw_data["objects"]
+        return self._raw_data["objects"] if isinstance(self._raw_data["objects"], dict) else {}
 
     @property
     def link(self) -> str:

--- a/nc_py_api/apps.py
+++ b/nc_py_api/apps.py
@@ -66,7 +66,7 @@ class _AppsAPI:
         """
         if not app_id:
             raise ValueError("`app_id` parameter can not be empty")
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/{app_id}")
+        self._session.ocs("DELETE", f"{self._ep_base}/{app_id}")
 
     def enable(self, app_id: str) -> None:
         """Enables the application.
@@ -75,7 +75,7 @@ class _AppsAPI:
         """
         if not app_id:
             raise ValueError("`app_id` parameter can not be empty")
-        self._session.ocs(method="POST", path=f"{self._ep_base}/{app_id}")
+        self._session.ocs("POST", f"{self._ep_base}/{app_id}")
 
     def get_list(self, enabled: typing.Optional[bool] = None) -> list[str]:
         """Get the list of installed applications.
@@ -85,7 +85,7 @@ class _AppsAPI:
         params = None
         if enabled is not None:
             params = {"filter": "enabled" if enabled else "disabled"}
-        result = self._session.ocs(method="GET", path=self._ep_base, params=params)
+        result = self._session.ocs("GET", self._ep_base, params=params)
         return list(result["apps"].values()) if isinstance(result["apps"], dict) else result["apps"]
 
     def is_installed(self, app_id: str) -> bool:
@@ -113,7 +113,7 @@ class _AppsAPI:
         """
         if not app_id:
             raise ValueError("`app_id` parameter can not be empty")
-        self._session.ocs(method="PUT", path=f"{self._session.ae_url}/ex-app/{app_id}/enabled", json={"enabled": 0})
+        self._session.ocs("PUT", f"{self._session.ae_url}/ex-app/{app_id}/enabled", json={"enabled": 0})
 
     def ex_app_enable(self, app_id: str) -> None:
         """Enables the external application.
@@ -122,7 +122,7 @@ class _AppsAPI:
         """
         if not app_id:
             raise ValueError("`app_id` parameter can not be empty")
-        self._session.ocs(method="PUT", path=f"{self._session.ae_url}/ex-app/{app_id}/enabled", json={"enabled": 1})
+        self._session.ocs("PUT", f"{self._session.ae_url}/ex-app/{app_id}/enabled", json={"enabled": 1})
 
     def ex_app_get_list(self, enabled: bool = False) -> list[ExAppInfo]:
         """Gets information of the enabled external applications installed on the server.
@@ -132,7 +132,7 @@ class _AppsAPI:
         """
         require_capabilities("app_api", self._session.capabilities)
         url_param = "enabled" if enabled else "all"
-        r = self._session.ocs(method="GET", path=f"{self._session.ae_url}/ex-app/{url_param}")
+        r = self._session.ocs("GET", f"{self._session.ae_url}/ex-app/{url_param}")
         return [ExAppInfo(i) for i in r]
 
     def ex_app_is_enabled(self, app_id: str) -> bool:

--- a/nc_py_api/calendar.py
+++ b/nc_py_api/calendar.py
@@ -22,7 +22,9 @@ try:
                 body = body.encode("UTF-8")
             if body:
                 body = body.replace(b"\n", b"\r\n").replace(b"\r\r\n", b"\r\n")
-            r = self._session.dav(method, url, data=body, headers=headers)
+            r = self._session.adapter_dav.request(
+                method, url if isinstance(url, str) else str(url), content=body, headers=headers
+            )
             return DAVResponse(r)
 
 except ImportError:

--- a/nc_py_api/ex_app/ui/files_actions.py
+++ b/nc_py_api/ex_app/ui/files_actions.py
@@ -139,13 +139,13 @@ class _UiFilesActionsAPI:
             "permissions": kwargs.get("permissions", 31),
             "order": kwargs.get("order", 0),
         }
-        self._session.ocs(method="POST", path=f"{self._session.ae_url}/{self._ep_suffix}", json=params)
+        self._session.ocs("POST", f"{self._session.ae_url}/{self._ep_suffix}", json=params)
 
     def unregister(self, name: str, not_fail=True) -> None:
         """Removes files dropdown menu element."""
         require_capabilities("app_api", self._session.capabilities)
         try:
-            self._session.ocs(method="DELETE", path=f"{self._session.ae_url}/{self._ep_suffix}", json={"name": name})
+            self._session.ocs("DELETE", f"{self._session.ae_url}/{self._ep_suffix}", json={"name": name})
         except NextcloudExceptionNotFound as e:
             if not not_fail:
                 raise e from None
@@ -155,7 +155,7 @@ class _UiFilesActionsAPI:
         require_capabilities("app_api", self._session.capabilities)
         try:
             return UiFileActionEntry(
-                self._session.ocs(method="GET", path=f"{self._session.ae_url}/{self._ep_suffix}", params={"name": name})
+                self._session.ocs("GET", f"{self._session.ae_url}/{self._ep_suffix}", params={"name": name})
             )
         except NextcloudExceptionNotFound:
             return None

--- a/nc_py_api/ex_app/ui/resources.py
+++ b/nc_py_api/ex_app/ui/resources.py
@@ -96,15 +96,15 @@ class _UiResources:
             "key": key,
             "value": value,
         }
-        self._session.ocs(method="POST", path=f"{self._session.ae_url}/{self._ep_suffix_init_state}", json=params)
+        self._session.ocs("POST", f"{self._session.ae_url}/{self._ep_suffix_init_state}", json=params)
 
     def delete_initial_state(self, ui_type: str, name: str, key: str, not_fail=True) -> None:
         """Removes initial state for the page(template) by object name."""
         require_capabilities("app_api", self._session.capabilities)
         try:
             self._session.ocs(
-                method="DELETE",
-                path=f"{self._session.ae_url}/{self._ep_suffix_init_state}",
+                "DELETE",
+                f"{self._session.ae_url}/{self._ep_suffix_init_state}",
                 params={"type": ui_type, "name": name, "key": key},
             )
         except NextcloudExceptionNotFound as e:
@@ -117,8 +117,8 @@ class _UiResources:
         try:
             return UiInitState(
                 self._session.ocs(
-                    method="GET",
-                    path=f"{self._session.ae_url}/{self._ep_suffix_init_state}",
+                    "GET",
+                    f"{self._session.ae_url}/{self._ep_suffix_init_state}",
                     params={"type": ui_type, "name": name, "key": key},
                 )
             )
@@ -134,15 +134,15 @@ class _UiResources:
             "path": path,
             "afterAppId": after_app_id,
         }
-        self._session.ocs(method="POST", path=f"{self._session.ae_url}/{self._ep_suffix_js}", json=params)
+        self._session.ocs("POST", f"{self._session.ae_url}/{self._ep_suffix_js}", json=params)
 
     def delete_script(self, ui_type: str, name: str, path: str, not_fail=True) -> None:
         """Removes script for the page(template) by object name."""
         require_capabilities("app_api", self._session.capabilities)
         try:
             self._session.ocs(
-                method="DELETE",
-                path=f"{self._session.ae_url}/{self._ep_suffix_js}",
+                "DELETE",
+                f"{self._session.ae_url}/{self._ep_suffix_js}",
                 params={"type": ui_type, "name": name, "path": path},
             )
         except NextcloudExceptionNotFound as e:
@@ -155,8 +155,8 @@ class _UiResources:
         try:
             return UiScript(
                 self._session.ocs(
-                    method="GET",
-                    path=f"{self._session.ae_url}/{self._ep_suffix_js}",
+                    "GET",
+                    f"{self._session.ae_url}/{self._ep_suffix_js}",
                     params={"type": ui_type, "name": name, "path": path},
                 )
             )
@@ -171,15 +171,15 @@ class _UiResources:
             "name": name,
             "path": path,
         }
-        self._session.ocs(method="POST", path=f"{self._session.ae_url}/{self._ep_suffix_css}", json=params)
+        self._session.ocs("POST", f"{self._session.ae_url}/{self._ep_suffix_css}", json=params)
 
     def delete_style(self, ui_type: str, name: str, path: str, not_fail=True) -> None:
         """Removes style(css) for the page(template) by object name."""
         require_capabilities("app_api", self._session.capabilities)
         try:
             self._session.ocs(
-                method="DELETE",
-                path=f"{self._session.ae_url}/{self._ep_suffix_css}",
+                "DELETE",
+                f"{self._session.ae_url}/{self._ep_suffix_css}",
                 params={"type": ui_type, "name": name, "path": path},
             )
         except NextcloudExceptionNotFound as e:
@@ -192,8 +192,8 @@ class _UiResources:
         try:
             return UiStyle(
                 self._session.ocs(
-                    method="GET",
-                    path=f"{self._session.ae_url}/{self._ep_suffix_css}",
+                    "GET",
+                    f"{self._session.ae_url}/{self._ep_suffix_css}",
                     params={"type": ui_type, "name": name, "path": path},
                 )
             )

--- a/nc_py_api/ex_app/ui/top_menu.py
+++ b/nc_py_api/ex_app/ui/top_menu.py
@@ -67,13 +67,13 @@ class _UiTopMenuAPI:
             "icon": icon,
             "adminRequired": int(admin_required),
         }
-        self._session.ocs(method="POST", path=f"{self._session.ae_url}/{self._ep_suffix}", json=params)
+        self._session.ocs("POST", f"{self._session.ae_url}/{self._ep_suffix}", json=params)
 
     def unregister(self, name: str, not_fail=True) -> None:
         """Removes App entry in Top Menu."""
         require_capabilities("app_api", self._session.capabilities)
         try:
-            self._session.ocs(method="DELETE", path=f"{self._session.ae_url}/{self._ep_suffix}", params={"name": name})
+            self._session.ocs("DELETE", f"{self._session.ae_url}/{self._ep_suffix}", params={"name": name})
         except NextcloudExceptionNotFound as e:
             if not not_fail:
                 raise e from None
@@ -83,7 +83,7 @@ class _UiTopMenuAPI:
         require_capabilities("app_api", self._session.capabilities)
         try:
             return UiTopMenuEntry(
-                self._session.ocs(method="GET", path=f"{self._session.ae_url}/{self._ep_suffix}", params={"name": name})
+                self._session.ocs("GET", f"{self._session.ae_url}/{self._ep_suffix}", params={"name": name})
             )
         except NextcloudExceptionNotFound:
             return None

--- a/nc_py_api/files/files.py
+++ b/nc_py_api/files/files.py
@@ -684,9 +684,7 @@ class FilesAPI:
                 _add_value(xml_element_where, where_part)
 
     def __download2stream(self, path: str, fp, **kwargs) -> None:
-        with self._session.dav_stream(
-            "GET", self._dav_get_obj_path(self._session.user, path)
-        ) as response:  # type: ignore
+        with self._session.adapter_dav.stream("GET", self._dav_get_obj_path(self._session.user, path)) as response:
             self._session.response_headers = response.headers
             check_error(response.status_code, f"download_stream: user={self._session.user}, path={path}")
             for data_chunk in response.iter_raw(chunk_size=kwargs.get("chunk_size", 5 * 1024 * 1024)):

--- a/nc_py_api/files/files.py
+++ b/nc_py_api/files/files.py
@@ -174,7 +174,6 @@ class FilesAPI:
         with self._session.adapter.stream(
             "GET", "/index.php/apps/files/ajax/download.php", params={"dir": path}
         ) as response:
-            self._session.response_headers = response.headers
             check_error(response, f"download_directory_as_zip: user={self._session.user}, path={path}")
             result_path = local_path if local_path else os.path.basename(path)
             with open(
@@ -688,7 +687,6 @@ class FilesAPI:
 
     def __download2stream(self, path: str, fp, **kwargs) -> None:
         with self._session.adapter_dav.stream("GET", self._dav_get_obj_path(self._session.user, path)) as response:
-            self._session.response_headers = response.headers
             check_error(response, f"download_stream: user={self._session.user}, path={path}")
             for data_chunk in response.iter_raw(chunk_size=kwargs.get("chunk_size", 5 * 1024 * 1024)):
                 fp.write(data_chunk)

--- a/nc_py_api/files/files.py
+++ b/nc_py_api/files/files.py
@@ -169,9 +169,9 @@ class FilesAPI:
         .. note:: This works only for directories, you should not use this to download a file.
         """
         path = path.user_path if isinstance(path, FsNode) else path
-        with self._session.get_stream(
-            "/index.php/apps/files/ajax/download.php", params={"dir": path}
-        ) as response:  # type: ignore
+        with self._session.adapter.stream(
+            "GET", "/index.php/apps/files/ajax/download.php", params={"dir": path}
+        ) as response:
             self._session.response_headers = response.headers
             check_error(response.status_code, f"download_directory_as_zip: user={self._session.user}, path={path}")
             result_path = local_path if local_path else os.path.basename(path)

--- a/nc_py_api/files/sharing.py
+++ b/nc_py_api/files/sharing.py
@@ -38,19 +38,19 @@ class _FilesSharingAPI:
         }
         if path:
             params["path"] = path
-        result = self._session.ocs(method="GET", path=f"{self._ep_base}/shares", params=params)
+        result = self._session.ocs("GET", f"{self._ep_base}/shares", params=params)
         return [Share(i) for i in result]
 
     def get_by_id(self, share_id: int) -> Share:
         """Get Share by share ID."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
-        result = self._session.ocs(method="GET", path=f"{self._ep_base}/shares/{share_id}")
+        result = self._session.ocs("GET", f"{self._ep_base}/shares/{share_id}")
         return Share(result[0] if isinstance(result, list) else result)
 
     def get_inherited(self, path: str) -> list[Share]:
         """Get all shares relative to a file, e.g., parent folders shares."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
-        result = self._session.ocs(method="GET", path=f"{self._ep_base}/shares/inherited", params={"path": path})
+        result = self._session.ocs("GET", f"{self._ep_base}/shares/inherited", params={"path": path})
         return [Share(i) for i in result]
 
     def create(
@@ -102,7 +102,7 @@ class _FilesSharingAPI:
             params["note"] = kwargs["note"]
         if "label" in kwargs:
             params["label"] = kwargs["label"]
-        return Share(self._session.ocs(method="POST", path=f"{self._ep_base}/shares", params=params))
+        return Share(self._session.ocs("POST", f"{self._ep_base}/shares", params=params))
 
     def update(self, share_id: typing.Union[int, Share], **kwargs) -> Share:
         """Updates the share options.
@@ -128,7 +128,7 @@ class _FilesSharingAPI:
             params["note"] = kwargs["note"]
         if "label" in kwargs:
             params["label"] = kwargs["label"]
-        return Share(self._session.ocs(method="PUT", path=f"{self._ep_base}/shares/{share_id}", params=params))
+        return Share(self._session.ocs("PUT", f"{self._ep_base}/shares/{share_id}", params=params))
 
     def delete(self, share_id: typing.Union[int, Share]) -> None:
         """Removes the given share.
@@ -137,31 +137,31 @@ class _FilesSharingAPI:
         """
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         share_id = share_id.share_id if isinstance(share_id, Share) else share_id
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/shares/{share_id}")
+        self._session.ocs("DELETE", f"{self._ep_base}/shares/{share_id}")
 
     def get_pending(self) -> list[Share]:
         """Returns all pending shares for current user."""
-        return [Share(i) for i in self._session.ocs(method="GET", path=f"{self._ep_base}/shares/pending")]
+        return [Share(i) for i in self._session.ocs("GET", f"{self._ep_base}/shares/pending")]
 
     def accept_share(self, share_id: typing.Union[int, Share]) -> None:
         """Accept pending share."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         share_id = share_id.share_id if isinstance(share_id, Share) else share_id
-        self._session.ocs(method="POST", path=f"{self._ep_base}/pending/{share_id}")
+        self._session.ocs("POST", f"{self._ep_base}/pending/{share_id}")
 
     def decline_share(self, share_id: typing.Union[int, Share]) -> None:
         """Decline pending share."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         share_id = share_id.share_id if isinstance(share_id, Share) else share_id
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/pending/{share_id}")
+        self._session.ocs("DELETE", f"{self._ep_base}/pending/{share_id}")
 
     def get_deleted(self) -> list[Share]:
         """Get a list of deleted shares."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
-        return [Share(i) for i in self._session.ocs(method="GET", path=f"{self._ep_base}/deletedshares")]
+        return [Share(i) for i in self._session.ocs("GET", f"{self._ep_base}/deletedshares")]
 
     def undelete(self, share_id: typing.Union[int, Share]) -> None:
         """Undelete a deleted share."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         share_id = share_id.share_id if isinstance(share_id, Share) else share_id
-        self._session.ocs(method="POST", path=f"{self._ep_base}/deletedshares/{share_id}")
+        self._session.ocs("POST", f"{self._ep_base}/deletedshares/{share_id}")

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -166,13 +166,11 @@ class NextcloudApp(_NextcloudBasic):
             return
         if int(log_lvl) < self.capabilities["app_api"].get("loglevel", 0):
             return
-        self._session.ocs(
-            method="POST", path=f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content}
-        )
+        self._session.ocs("POST", f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content})
 
     def users_list(self) -> list[str]:
         """Returns list of users on the Nextcloud instance. **Available** only for ``System`` applications."""
-        return self._session.ocs("GET", path=f"{self._session.ae_url}/users", params={"format": "json"})
+        return self._session.ocs("GET", f"{self._session.ae_url}/users", params={"format": "json"})
 
     def scope_allowed(self, scope: ApiScope) -> bool:
         """Check if API scope is avalaible for application.
@@ -223,7 +221,7 @@ class NextcloudApp(_NextcloudBasic):
             "route": callback_url,
             "description": description,
         }
-        result = self._session.ocs(method="POST", path=f"{self._session.ae_url}/talk_bot", json=params)
+        result = self._session.ocs("POST", f"{self._session.ae_url}/talk_bot", json=params)
         return result["id"], result["secret"]
 
     def unregister_talk_bot(self, callback_url: str) -> bool:
@@ -238,7 +236,7 @@ class NextcloudApp(_NextcloudBasic):
             "route": callback_url,
         }
         try:
-            self._session.ocs(method="DELETE", path=f"{self._session.ae_url}/talk_bot", json=params)
+            self._session.ocs("DELETE", f"{self._session.ae_url}/talk_bot", json=params)
         except NextcloudExceptionNotFound:
             return False
         return True
@@ -265,8 +263,8 @@ class NextcloudApp(_NextcloudBasic):
         :param error: if non-empty, signals to AppAPI that the application cannot be initialized successfully.
         """
         self._session.ocs(
-            method="PUT",
-            path=f"/ocs/v1.php/apps/app_api/apps/status/{self._session.cfg.app_name}",
+            "PUT",
+            f"/ocs/v1.php/apps/app_api/apps/status/{self._session.cfg.app_name}",
             json={
                 "progress": progress,
                 "error": error,

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -276,5 +276,4 @@ class NextcloudApp(_NextcloudBasic):
                 "progress": progress,
                 "error": error,
             },
-            not_parse=True,
         )

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -98,11 +98,6 @@ class _NextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         return self._session.response_headers
 
     @property
-    def response_headers_dav(self) -> HttpxHeaders:
-        """Returns the `HTTPX headers <https://www.python-httpx.org/api/#headers>`_ from the last DAV response."""
-        return self._session.response_headers_dav
-
-    @property
     def theme(self) -> Optional[ThemingInfo]:
         """Returns Theme information."""
         return get_parsed_theme(self.capabilities["theming"]) if "theming" in self.capabilities else None

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -98,6 +98,11 @@ class _NextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         return self._session.response_headers
 
     @property
+    def response_headers_dav(self) -> HttpxHeaders:
+        """Returns the `HTTPX headers <https://www.python-httpx.org/api/#headers>`_ from the last DAV response."""
+        return self._session.response_headers_dav
+
+    @property
     def theme(self) -> Optional[ThemingInfo]:
         """Returns Theme information."""
         return get_parsed_theme(self.capabilities["theming"]) if "theming" in self.capabilities else None

--- a/nc_py_api/notes.py
+++ b/nc_py_api/notes.py
@@ -2,8 +2,12 @@
 
 import dataclasses
 import datetime
+import json
 import typing
 
+import httpx
+
+from ._exceptions import check_error
 from ._misc import check_capabilities, clear_from_params_empty, require_capabilities
 from ._session import NcSessionBasic
 
@@ -136,15 +140,17 @@ class _NotesAPI:
         }
         clear_from_params_empty(list(params.keys()), params)
         headers = {"If-None-Match": self.last_etag} if self.last_etag and etag else {}
-        r = self._session.request_json("GET", self._ep_base + "/notes", params=params, headers=headers)
+        r = self.__response_to_json(self._session.adapter.get(self._ep_base + "/notes", params=params, headers=headers))
         self.last_etag = self._session.response_headers["ETag"]
         return [Note(i) for i in r]
 
     def by_id(self, note: Note) -> Note:
         """Get updated information about :py:class:`~nc_py_api.notes.Note`."""
         require_capabilities("notes", self._session.capabilities)
-        r = self._session.request_json(
-            "GET", self._ep_base + f"/notes/{note.note_id}", headers={"If-None-Match": f'"{note.etag}"'}
+        r = self.__response_to_json(
+            self._session.adapter.get(
+                self._ep_base + f"/notes/{note.note_id}", headers={"If-None-Match": f'"{note.etag}"'}
+            )
         )
         return Note(r) if r else note
 
@@ -166,7 +172,7 @@ class _NotesAPI:
             "modified": last_modified,
         }
         clear_from_params_empty(list(params.keys()), params)
-        return Note(self._session.request_json("POST", self._ep_base + "/notes", json=params))
+        return Note(self.__response_to_json(self._session.adapter.post(self._ep_base + "/notes", json=params)))
 
     def update(
         self,
@@ -193,7 +199,9 @@ class _NotesAPI:
         if not params:
             raise ValueError("Nothing to update.")
         return Note(
-            self._session.request_json("PUT", self._ep_base + f"/notes/{note.note_id}", json=params, headers=headers)
+            self.__response_to_json(
+                self._session.adapter.put(self._ep_base + f"/notes/{note.note_id}", json=params, headers=headers)
+            )
         )
 
     def delete(self, note: typing.Union[int, Note]) -> None:
@@ -208,7 +216,7 @@ class _NotesAPI:
     def get_settings(self) -> NotesSettings:
         """Returns Notes App settings."""
         require_capabilities("notes", self._session.capabilities)
-        r = self._session.request_json("GET", self._ep_base + "/settings")
+        r = self.__response_to_json(self._session.adapter.get(self._ep_base + "/settings"))
         return {"notes_path": r["notesPath"], "file_suffix": r["fileSuffix"]}
 
     def set_settings(self, notes_path: typing.Optional[str] = None, file_suffix: typing.Optional[str] = None) -> None:
@@ -222,3 +230,8 @@ class _NotesAPI:
         }
         clear_from_params_empty(list(params.keys()), params)
         self._session.ocs("PUT", self._ep_base + "/settings", not_parse=True, json=params)
+
+    @staticmethod
+    def __response_to_json(response: httpx.Response) -> dict:
+        check_error(response.status_code, info=f"request: {response.request.method} {response.request.url}")
+        return json.loads(response.text) if response.status_code != 304 else {}

--- a/nc_py_api/notes.py
+++ b/nc_py_api/notes.py
@@ -211,7 +211,8 @@ class _NotesAPI:
         """
         require_capabilities("notes", self._session.capabilities)
         note_id = note.note_id if isinstance(note, Note) else note
-        self._session.ocs("DELETE", self._ep_base + f"/notes/{note_id}", not_parse=True)
+        response = self._session.adapter.delete(self._ep_base + f"/notes/{note_id}")
+        check_error(response.status_code)
 
     def get_settings(self) -> NotesSettings:
         """Returns Notes App settings."""
@@ -229,7 +230,8 @@ class _NotesAPI:
             "fileSuffix": file_suffix,
         }
         clear_from_params_empty(list(params.keys()), params)
-        self._session.ocs("PUT", self._ep_base + "/settings", not_parse=True, json=params)
+        response = self._session.adapter.put(self._ep_base + "/settings", json=params)
+        check_error(response.status_code)
 
     @staticmethod
     def __response_to_json(response: httpx.Response) -> dict:

--- a/nc_py_api/notes.py
+++ b/nc_py_api/notes.py
@@ -211,8 +211,7 @@ class _NotesAPI:
         """
         require_capabilities("notes", self._session.capabilities)
         note_id = note.note_id if isinstance(note, Note) else note
-        response = self._session.adapter.delete(self._ep_base + f"/notes/{note_id}")
-        check_error(response.status_code)
+        check_error(self._session.adapter.delete(self._ep_base + f"/notes/{note_id}"))
 
     def get_settings(self) -> NotesSettings:
         """Returns Notes App settings."""
@@ -230,10 +229,9 @@ class _NotesAPI:
             "fileSuffix": file_suffix,
         }
         clear_from_params_empty(list(params.keys()), params)
-        response = self._session.adapter.put(self._ep_base + "/settings", json=params)
-        check_error(response.status_code)
+        check_error(self._session.adapter.put(self._ep_base + "/settings", json=params))
 
     @staticmethod
     def __response_to_json(response: httpx.Response) -> dict:
-        check_error(response.status_code, info=f"request: {response.request.method} {response.request.url}")
+        check_error(response)
         return json.loads(response.text) if response.status_code != 304 else {}

--- a/nc_py_api/notifications.py
+++ b/nc_py_api/notifications.py
@@ -126,17 +126,17 @@ class _NotificationsAPI:
         }
         if link:
             params["params"]["subject_params"]["link"] = link
-        return self._session.ocs(method="POST", path=f"{self._session.ae_url}/notification", json=params)["object_id"]
+        return self._session.ocs("POST", f"{self._session.ae_url}/notification", json=params)["object_id"]
 
     def get_all(self) -> list[Notification]:
         """Gets all notifications for a current user."""
         require_capabilities("notifications", self._session.capabilities)
-        return [Notification(i) for i in self._session.ocs(method="GET", path=self._ep_base)]
+        return [Notification(i) for i in self._session.ocs("GET", self._ep_base)]
 
     def get_one(self, notification_id: int) -> Notification:
         """Gets a single notification for a current user."""
         require_capabilities("notifications", self._session.capabilities)
-        return Notification(self._session.ocs(method="GET", path=f"{self._ep_base}/{notification_id}"))
+        return Notification(self._session.ocs("GET", f"{self._ep_base}/{notification_id}"))
 
     def by_object_id(self, object_id: str) -> typing.Optional[Notification]:
         """Returns Notification if any by its object ID.
@@ -151,14 +151,14 @@ class _NotificationsAPI:
     def delete(self, notification_id: int) -> None:
         """Deletes a notification for the current user."""
         require_capabilities("notifications", self._session.capabilities)
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/{notification_id}")
+        self._session.ocs("DELETE", f"{self._ep_base}/{notification_id}")
 
     def delete_all(self) -> None:
         """Deletes all notifications for the current user."""
         require_capabilities("notifications", self._session.capabilities)
-        self._session.ocs(method="DELETE", path=self._ep_base)
+        self._session.ocs("DELETE", self._ep_base)
 
     def exists(self, notification_ids: list[int]) -> list[int]:
         """Checks the existence of notifications for the current user."""
         require_capabilities("notifications", self._session.capabilities)
-        return self._session.ocs(method="POST", path=f"{self._ep_base}/exists", json={"ids": notification_ids})
+        return self._session.ocs("POST", f"{self._ep_base}/exists", json={"ids": notification_ids})

--- a/nc_py_api/user_status.py
+++ b/nc_py_api/user_status.py
@@ -128,13 +128,13 @@ class _UserStatusAPI:
         """
         require_capabilities("user_status.enabled", self._session.capabilities)
         data = kwargs_to_params(["limit", "offset"], limit=limit, offset=offset)
-        result = self._session.ocs(method="GET", path=f"{self._ep_base}/statuses", params=data)
+        result = self._session.ocs("GET", f"{self._ep_base}/statuses", params=data)
         return [UserStatus(i) for i in result]
 
     def get_current(self) -> CurrentUserStatus:
         """Returns the current user status."""
         require_capabilities("user_status.enabled", self._session.capabilities)
-        return CurrentUserStatus(self._session.ocs(method="GET", path=f"{self._ep_base}/user_status"))
+        return CurrentUserStatus(self._session.ocs("GET", f"{self._ep_base}/user_status"))
 
     def get(self, user_id: str) -> typing.Optional[UserStatus]:
         """Returns the user status for the specified user.
@@ -143,7 +143,7 @@ class _UserStatusAPI:
         """
         require_capabilities("user_status.enabled", self._session.capabilities)
         try:
-            return UserStatus(self._session.ocs(method="GET", path=f"{self._ep_base}/statuses/{user_id}"))
+            return UserStatus(self._session.ocs("GET", f"{self._ep_base}/statuses/{user_id}"))
         except NextcloudExceptionNotFound:
             return None
 
@@ -152,7 +152,7 @@ class _UserStatusAPI:
         if self._session.nc_version["major"] < 27:
             return []
         require_capabilities("user_status.enabled", self._session.capabilities)
-        result = self._session.ocs(method="GET", path=f"{self._ep_base}/predefined_statuses")
+        result = self._session.ocs("GET", f"{self._ep_base}/predefined_statuses")
         return [PredefinedStatus(i) for i in result]
 
     def set_predefined(self, status_id: str, clear_at: int = 0) -> None:
@@ -167,12 +167,12 @@ class _UserStatusAPI:
         params: dict[str, typing.Union[int, str]] = {"messageId": status_id}
         if clear_at:
             params["clearAt"] = clear_at
-        self._session.ocs(method="PUT", path=f"{self._ep_base}/user_status/message/predefined", params=params)
+        self._session.ocs("PUT", f"{self._ep_base}/user_status/message/predefined", params=params)
 
     def set_status_type(self, value: typing.Literal["online", "away", "dnd", "invisible", "offline"]) -> None:
         """Sets the status type for the current user."""
         require_capabilities("user_status.enabled", self._session.capabilities)
-        self._session.ocs(method="PUT", path=f"{self._ep_base}/user_status/status", params={"statusType": value})
+        self._session.ocs("PUT", f"{self._ep_base}/user_status/status", params={"statusType": value})
 
     def set_status(self, message: typing.Optional[str] = None, clear_at: int = 0, status_icon: str = "") -> None:
         """Sets current user status.
@@ -183,7 +183,7 @@ class _UserStatusAPI:
         """
         require_capabilities("user_status.enabled", self._session.capabilities)
         if message is None:
-            self._session.ocs(method="DELETE", path=f"{self._ep_base}/user_status/message")
+            self._session.ocs("DELETE", f"{self._ep_base}/user_status/message")
             return
         if status_icon:
             require_capabilities("user_status.supports_emoji", self._session.capabilities)
@@ -192,7 +192,7 @@ class _UserStatusAPI:
             params["clearAt"] = clear_at
         if status_icon:
             params["statusIcon"] = status_icon
-        self._session.ocs(method="PUT", path=f"{self._ep_base}/user_status/message/custom", params=params)
+        self._session.ocs("PUT", f"{self._ep_base}/user_status/message/custom", params=params)
 
     def get_backup_status(self, user_id: str = "") -> typing.Optional[UserStatus]:
         """Get the backup status of the user if any.
@@ -212,5 +212,5 @@ class _UserStatusAPI:
         """
         require_capabilities("user_status.enabled", self._session.capabilities)
         require_capabilities("user_status.restore", self._session.capabilities)
-        result = self._session.ocs(method="DELETE", path=f"{self._ep_base}/user_status/revert/{status_id}")
+        result = self._session.ocs("DELETE", f"{self._ep_base}/user_status/revert/{status_id}")
         return result if result else None

--- a/nc_py_api/user_status.py
+++ b/nc_py_api/user_status.py
@@ -121,11 +121,7 @@ class _UserStatusAPI:
         return not check_capabilities("user_status.enabled", self._session.capabilities)
 
     def get_list(self, limit: typing.Optional[int] = None, offset: typing.Optional[int] = None) -> list[UserStatus]:
-        """Returns statuses for all users.
-
-        :param limit: limits the number of results.
-        :param offset: offset of results.
-        """
+        """Returns statuses for all users."""
         require_capabilities("user_status.enabled", self._session.capabilities)
         data = kwargs_to_params(["limit", "offset"], limit=limit, offset=offset)
         result = self._session.ocs("GET", f"{self._ep_base}/statuses", params=data)
@@ -137,10 +133,7 @@ class _UserStatusAPI:
         return CurrentUserStatus(self._session.ocs("GET", f"{self._ep_base}/user_status"))
 
     def get(self, user_id: str) -> typing.Optional[UserStatus]:
-        """Returns the user status for the specified user.
-
-        :param user_id: User ID for getting status.
-        """
+        """Returns the user status for the specified user."""
         require_capabilities("user_status.enabled", self._session.capabilities)
         try:
             return UserStatus(self._session.ocs("GET", f"{self._ep_base}/statuses/{user_id}"))
@@ -195,10 +188,7 @@ class _UserStatusAPI:
         self._session.ocs("PUT", f"{self._ep_base}/user_status/message/custom", params=params)
 
     def get_backup_status(self, user_id: str = "") -> typing.Optional[UserStatus]:
-        """Get the backup status of the user if any.
-
-        :param user_id: User ID for getting status.
-        """
+        """Get the backup status of the user if any."""
         require_capabilities("user_status.enabled", self._session.capabilities)
         user_id = user_id if user_id else self._session.user
         if not user_id:
@@ -206,10 +196,7 @@ class _UserStatusAPI:
         return self.get(f"_{user_id}")
 
     def restore_backup_status(self, status_id: str) -> typing.Optional[CurrentUserStatus]:
-        """Restores the backup state as current for the current user.
-
-        :param status_id: backup status ID.
-        """
+        """Restores the backup state as current for the current user."""
         require_capabilities("user_status.enabled", self._session.capabilities)
         require_capabilities("user_status.restore", self._session.capabilities)
         result = self._session.ocs("DELETE", f"{self._ep_base}/user_status/revert/{status_id}")

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime
 import typing
 
+from ._exceptions import check_error
 from ._misc import kwargs_to_params
 from ._session import NcSessionBasic
 
@@ -304,4 +305,6 @@ class _UsersAPI:
         url_path = f"/index.php/avatar/{user_id}/{size}" if not guest else f"/index.php/avatar/guest/{user_id}/{size}"
         if dark:
             url_path += "/dark"
-        return self._session.request(method="GET", path=url_path).content
+        response = self._session.adapter.get(url_path)
+        check_error(response.status_code, info=f"request: {response.request.method} {response.request.url}")
+        return response.content

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -306,5 +306,5 @@ class _UsersAPI:
         if dark:
             url_path += "/dark"
         response = self._session.adapter.get(url_path)
-        check_error(response.status_code, info=f"request: {response.request.method} {response.request.url}")
+        check_error(response)
         return response.content

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -177,7 +177,7 @@ class _UsersAPI:
         :param offset: offset of results.
         """
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
-        response_data = self._session.ocs(method="GET", path=self._ep_base, params=data)
+        response_data = self._session.ocs("GET", self._ep_base, params=data)
         return response_data["users"] if response_data else {}
 
     def get_user(self, user_id: str = "") -> UserInfo:
@@ -185,8 +185,7 @@ class _UsersAPI:
 
         :param user_id: the identifier of the user about which information is to be returned.
         """
-        url_path = f"{self._ep_base}/{user_id}" if user_id else "/ocs/v1.php/cloud/user"
-        return UserInfo(self._session.ocs(method="GET", path=url_path))
+        return UserInfo(self._session.ocs("GET", f"{self._ep_base}/{user_id}" if user_id else "/ocs/v1.php/cloud/user"))
 
     def create(self, user_id: str, display_name: typing.Optional[str] = None, **kwargs) -> None:
         """Create a new user on the Nextcloud server.
@@ -214,39 +213,39 @@ class _UsersAPI:
                 data[k] = kwargs[k]
         if display_name is not None:
             data["displayname"] = display_name
-        self._session.ocs(method="POST", path=self._ep_base, json=data)
+        self._session.ocs("POST", self._ep_base, json=data)
 
     def delete(self, user_id: str) -> None:
         """Deletes user from the Nextcloud server.
 
         :param user_id: id of the user.
         """
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/{user_id}")
+        self._session.ocs("DELETE", f"{self._ep_base}/{user_id}")
 
     def enable(self, user_id: str) -> None:
         """Enables user on the Nextcloud server.
 
         :param user_id: id of the user.
         """
-        self._session.ocs(method="PUT", path=f"{self._ep_base}/{user_id}/enable")
+        self._session.ocs("PUT", f"{self._ep_base}/{user_id}/enable")
 
     def disable(self, user_id: str) -> None:
         """Disables user on the Nextcloud server.
 
         :param user_id: id of the user.
         """
-        self._session.ocs(method="PUT", path=f"{self._ep_base}/{user_id}/disable")
+        self._session.ocs("PUT", f"{self._ep_base}/{user_id}/disable")
 
     def resend_welcome_email(self, user_id: str) -> None:
         """Send welcome email for specified user again.
 
         :param user_id: id of the user.
         """
-        self._session.ocs(method="POST", path=f"{self._ep_base}/{user_id}/welcome")
+        self._session.ocs("POST", f"{self._ep_base}/{user_id}/welcome")
 
     def editable_fields(self) -> list[str]:
         """Returns user fields that avalaible for edit."""
-        return self._session.ocs(method="GET", path="/ocs/v1.php/cloud/user/fields")
+        return self._session.ocs("GET", "/ocs/v1.php/cloud/user/fields")
 
     def edit(self, user_id: str, **kwargs) -> None:
         """Edits user metadata.
@@ -255,7 +254,7 @@ class _UsersAPI:
         :param kwargs: dictionary where keys are values from ``editable_fields`` method, and values to set.
         """
         for k, v in kwargs.items():
-            self._session.ocs(method="PUT", path=f"{self._ep_base}/{user_id}", params={"key": k, "value": v})
+            self._session.ocs("PUT", f"{self._ep_base}/{user_id}", params={"key": k, "value": v})
 
     def add_to_group(self, user_id: str, group_id: str) -> None:
         """Adds user to the group.
@@ -263,7 +262,7 @@ class _UsersAPI:
         :param user_id: ID of the user.
         :param group_id: the destination group to which add user to.
         """
-        self._session.ocs(method="POST", path=f"{self._ep_base}/{user_id}/groups", params={"groupid": group_id})
+        self._session.ocs("POST", f"{self._ep_base}/{user_id}/groups", params={"groupid": group_id})
 
     def remove_from_group(self, user_id: str, group_id: str) -> None:
         """Removes user from the group.
@@ -271,7 +270,7 @@ class _UsersAPI:
         :param user_id: ID of the user.
         :param group_id: group from which remove user.
         """
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/{user_id}/groups", params={"groupid": group_id})
+        self._session.ocs("DELETE", f"{self._ep_base}/{user_id}/groups", params={"groupid": group_id})
 
     def promote_to_subadmin(self, user_id: str, group_id: str) -> None:
         """Makes user admin of the group.
@@ -279,7 +278,7 @@ class _UsersAPI:
         :param user_id: ID of the user.
         :param group_id: group where user should become administrator.
         """
-        self._session.ocs(method="POST", path=f"{self._ep_base}/{user_id}/subadmins", params={"groupid": group_id})
+        self._session.ocs("POST", f"{self._ep_base}/{user_id}/subadmins", params={"groupid": group_id})
 
     def demote_from_subadmin(self, user_id: str, group_id: str) -> None:
         """Removes user from the admin role of the group.
@@ -287,7 +286,7 @@ class _UsersAPI:
         :param user_id: ID of the user.
         :param group_id: group where user should be removed from administrators.
         """
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/{user_id}/subadmins", params={"groupid": group_id})
+        self._session.ocs("DELETE", f"{self._ep_base}/{user_id}/subadmins", params={"groupid": group_id})
 
     def get_avatar(
         self, user_id: str = "", size: typing.Literal[64, 512] = 512, dark: bool = False, guest: bool = False

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -170,21 +170,13 @@ class _UsersAPI:
     def get_list(
         self, mask: typing.Optional[str] = "", limit: typing.Optional[int] = None, offset: typing.Optional[int] = None
     ) -> list[str]:
-        """Returns list of user IDs.
-
-        :param mask: user ID mask to apply.
-        :param limit: limits the number of results.
-        :param offset: offset of results.
-        """
+        """Returns list of user IDs."""
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
         response_data = self._session.ocs("GET", self._ep_base, params=data)
         return response_data["users"] if response_data else {}
 
     def get_user(self, user_id: str = "") -> UserInfo:
-        """Returns detailed user information.
-
-        :param user_id: the identifier of the user about which information is to be returned.
-        """
+        """Returns detailed user information."""
         return UserInfo(self._session.ocs("GET", f"{self._ep_base}/{user_id}" if user_id else "/ocs/v1.php/cloud/user"))
 
     def create(self, user_id: str, display_name: typing.Optional[str] = None, **kwargs) -> None:
@@ -216,31 +208,19 @@ class _UsersAPI:
         self._session.ocs("POST", self._ep_base, json=data)
 
     def delete(self, user_id: str) -> None:
-        """Deletes user from the Nextcloud server.
-
-        :param user_id: id of the user.
-        """
+        """Deletes user from the Nextcloud server."""
         self._session.ocs("DELETE", f"{self._ep_base}/{user_id}")
 
     def enable(self, user_id: str) -> None:
-        """Enables user on the Nextcloud server.
-
-        :param user_id: id of the user.
-        """
+        """Enables user on the Nextcloud server."""
         self._session.ocs("PUT", f"{self._ep_base}/{user_id}/enable")
 
     def disable(self, user_id: str) -> None:
-        """Disables user on the Nextcloud server.
-
-        :param user_id: id of the user.
-        """
+        """Disables user on the Nextcloud server."""
         self._session.ocs("PUT", f"{self._ep_base}/{user_id}/disable")
 
     def resend_welcome_email(self, user_id: str) -> None:
-        """Send welcome email for specified user again.
-
-        :param user_id: id of the user.
-        """
+        """Send welcome email for specified user again."""
         self._session.ocs("POST", f"{self._ep_base}/{user_id}/welcome")
 
     def editable_fields(self) -> list[str]:
@@ -257,35 +237,19 @@ class _UsersAPI:
             self._session.ocs("PUT", f"{self._ep_base}/{user_id}", params={"key": k, "value": v})
 
     def add_to_group(self, user_id: str, group_id: str) -> None:
-        """Adds user to the group.
-
-        :param user_id: ID of the user.
-        :param group_id: the destination group to which add user to.
-        """
+        """Adds user to the group."""
         self._session.ocs("POST", f"{self._ep_base}/{user_id}/groups", params={"groupid": group_id})
 
     def remove_from_group(self, user_id: str, group_id: str) -> None:
-        """Removes user from the group.
-
-        :param user_id: ID of the user.
-        :param group_id: group from which remove user.
-        """
+        """Removes user from the group."""
         self._session.ocs("DELETE", f"{self._ep_base}/{user_id}/groups", params={"groupid": group_id})
 
     def promote_to_subadmin(self, user_id: str, group_id: str) -> None:
-        """Makes user admin of the group.
-
-        :param user_id: ID of the user.
-        :param group_id: group where user should become administrator.
-        """
+        """Makes user admin of the group."""
         self._session.ocs("POST", f"{self._ep_base}/{user_id}/subadmins", params={"groupid": group_id})
 
     def demote_from_subadmin(self, user_id: str, group_id: str) -> None:
-        """Removes user from the admin role of the group.
-
-        :param user_id: ID of the user.
-        :param group_id: group where user should be removed from administrators.
-        """
+        """Removes user from the admin role of the group."""
         self._session.ocs("DELETE", f"{self._ep_base}/{user_id}/subadmins", params={"groupid": group_id})
 
     def get_avatar(

--- a/nc_py_api/users_groups.py
+++ b/nc_py_api/users_groups.py
@@ -69,7 +69,7 @@ class _UsersGroupsAPI:
         :param offset: offset of results.
         """
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
-        response_data = self._session.ocs(method="GET", path=self._ep_base, params=data)
+        response_data = self._session.ocs("GET", self._ep_base, params=data)
         return response_data["groups"] if response_data else []
 
     def get_details(
@@ -82,7 +82,7 @@ class _UsersGroupsAPI:
         :param offset: offset of results.
         """
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
-        response_data = self._session.ocs(method="GET", path=f"{self._ep_base}/details", params=data)
+        response_data = self._session.ocs("GET", f"{self._ep_base}/details", params=data)
         return [GroupDetails(i) for i in response_data["groups"]] if response_data else []
 
     def create(self, group_id: str, display_name: typing.Optional[str] = None) -> None:
@@ -94,7 +94,7 @@ class _UsersGroupsAPI:
         params = {"groupid": group_id}
         if display_name is not None:
             params["displayname"] = display_name
-        self._session.ocs(method="POST", path=f"{self._ep_base}", params=params)
+        self._session.ocs("POST", f"{self._ep_base}", params=params)
 
     def edit(self, group_id: str, display_name: str) -> None:
         """Edits users group information.
@@ -103,21 +103,21 @@ class _UsersGroupsAPI:
         :param display_name: new group display name.
         """
         params = {"key": "displayname", "value": display_name}
-        self._session.ocs(method="PUT", path=f"{self._ep_base}/{group_id}", params=params)
+        self._session.ocs("PUT", f"{self._ep_base}/{group_id}", params=params)
 
     def delete(self, group_id: str) -> None:
         """Removes the users group.
 
         :param group_id: the ID of group to remove.
         """
-        self._session.ocs(method="DELETE", path=f"{self._ep_base}/{group_id}")
+        self._session.ocs("DELETE", f"{self._ep_base}/{group_id}")
 
     def get_members(self, group_id: str) -> list[str]:
         """Returns a list of group users.
 
         :param group_id: Group ID to get the list of members.
         """
-        response_data = self._session.ocs(method="GET", path=f"{self._ep_base}/{group_id}")
+        response_data = self._session.ocs("GET", f"{self._ep_base}/{group_id}")
         return response_data["users"] if response_data else {}
 
     def get_subadmins(self, group_id: str) -> list[str]:
@@ -125,4 +125,4 @@ class _UsersGroupsAPI:
 
         :param group_id: group ID to get the list of subadmins.
         """
-        return self._session.ocs(method="GET", path=f"{self._ep_base}/{group_id}/subadmins")
+        return self._session.ocs("GET", f"{self._ep_base}/{group_id}/subadmins")

--- a/nc_py_api/users_groups.py
+++ b/nc_py_api/users_groups.py
@@ -62,12 +62,7 @@ class _UsersGroupsAPI:
     def get_list(
         self, mask: typing.Optional[str] = None, limit: typing.Optional[int] = None, offset: typing.Optional[int] = None
     ) -> list[str]:
-        """Returns a list of user groups IDs.
-
-        :param mask: group ID mask to apply.
-        :param limit: limits the number of results.
-        :param offset: offset of results.
-        """
+        """Returns a list of user groups IDs."""
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
         response_data = self._session.ocs("GET", self._ep_base, params=data)
         return response_data["groups"] if response_data else []
@@ -75,54 +70,32 @@ class _UsersGroupsAPI:
     def get_details(
         self, mask: typing.Optional[str] = None, limit: typing.Optional[int] = None, offset: typing.Optional[int] = None
     ) -> list[GroupDetails]:
-        """Returns a list of user groups with detailed information.
-
-        :param mask: group ID mask to apply.
-        :param limit: limits the number of results.
-        :param offset: offset of results.
-        """
+        """Returns a list of user groups with detailed information."""
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
         response_data = self._session.ocs("GET", f"{self._ep_base}/details", params=data)
         return [GroupDetails(i) for i in response_data["groups"]] if response_data else []
 
     def create(self, group_id: str, display_name: typing.Optional[str] = None) -> None:
-        """Creates the users group.
-
-        :param group_id: the ID of group to be created.
-        :param display_name: display name for a created group.
-        """
+        """Creates the users group."""
         params = {"groupid": group_id}
         if display_name is not None:
             params["displayname"] = display_name
         self._session.ocs("POST", f"{self._ep_base}", params=params)
 
     def edit(self, group_id: str, display_name: str) -> None:
-        """Edits users group information.
-
-        :param group_id: the ID of group to edit info.
-        :param display_name: new group display name.
-        """
+        """Edits users group information."""
         params = {"key": "displayname", "value": display_name}
         self._session.ocs("PUT", f"{self._ep_base}/{group_id}", params=params)
 
     def delete(self, group_id: str) -> None:
-        """Removes the users group.
-
-        :param group_id: the ID of group to remove.
-        """
+        """Removes the users group."""
         self._session.ocs("DELETE", f"{self._ep_base}/{group_id}")
 
     def get_members(self, group_id: str) -> list[str]:
-        """Returns a list of group users.
-
-        :param group_id: Group ID to get the list of members.
-        """
+        """Returns a list of group users."""
         response_data = self._session.ocs("GET", f"{self._ep_base}/{group_id}")
         return response_data["users"] if response_data else {}
 
     def get_subadmins(self, group_id: str) -> list[str]:
-        """Returns list of users who is subadmins of the group.
-
-        :param group_id: group ID to get the list of subadmins.
-        """
+        """Returns list of users who is subadmins of the group."""
         return self._session.ocs("GET", f"{self._ep_base}/{group_id}/subadmins")

--- a/nc_py_api/weather_status.py
+++ b/nc_py_api/weather_status.py
@@ -57,7 +57,7 @@ class _WeatherStatusAPI:
     def get_location(self) -> WeatherLocation:
         """Returns the current location set on the Nextcloud server for the user."""
         require_capabilities("weather_status.enabled", self._session.capabilities)
-        return WeatherLocation(self._session.ocs(method="GET", path=f"{self._ep_base}/location"))
+        return WeatherLocation(self._session.ocs("GET", f"{self._ep_base}/location"))
 
     def set_location(
         self,
@@ -79,23 +79,23 @@ class _WeatherStatusAPI:
             params["address"] = address
         else:
             raise ValueError("latitude & longitude or address should be present")
-        result = self._session.ocs(method="PUT", path=f"{self._ep_base}/location", params=params)
+        result = self._session.ocs("PUT", f"{self._ep_base}/location", params=params)
         return result.get("success", False)
 
     def get_forecast(self) -> list[dict]:
         """Get forecast for the current location."""
         require_capabilities("weather_status.enabled", self._session.capabilities)
-        return self._session.ocs(method="GET", path=f"{self._ep_base}/forecast")
+        return self._session.ocs("GET", f"{self._ep_base}/forecast")
 
     def get_favorites(self) -> list[str]:
         """Returns favorites addresses list."""
         require_capabilities("weather_status.enabled", self._session.capabilities)
-        return self._session.ocs(method="GET", path=f"{self._ep_base}/favorites")
+        return self._session.ocs("GET", f"{self._ep_base}/favorites")
 
     def set_favorites(self, favorites: list[str]) -> bool:
         """Sets favorites addresses list."""
         require_capabilities("weather_status.enabled", self._session.capabilities)
-        result = self._session.ocs(method="PUT", path=f"{self._ep_base}/favorites", json={"favorites": favorites})
+        result = self._session.ocs("PUT", f"{self._ep_base}/favorites", json={"favorites": favorites})
         return result.get("success", False)
 
     def set_mode(self, mode: WeatherLocationMode) -> bool:
@@ -103,5 +103,5 @@ class _WeatherStatusAPI:
         if int(mode) == WeatherLocationMode.UNKNOWN.value:
             raise ValueError("This mode can not be set")
         require_capabilities("weather_status.enabled", self._session.capabilities)
-        result = self._session.ocs(method="PUT", path=f"{self._ep_base}/mode", params={"mode": int(mode)})
+        result = self._session.ocs("PUT", f"{self._ep_base}/mode", params={"mode": int(mode)})
         return result.get("success", False)

--- a/tests/actual_tests/appcfg_prefs_ex_test.py
+++ b/tests/actual_tests/appcfg_prefs_ex_test.py
@@ -124,21 +124,21 @@ def test_appcfg_sensitive(nc_app):
     appcfg.delete("test_key")
     # next code tests `sensitive` value from the `AppAPI`
     params = {"configKey": "test_key", "configValue": "123"}
-    result = nc_app._session.ocs(method="POST", path=f"{nc_app._session.ae_url}/{appcfg._url_suffix}", json=params)
+    result = nc_app._session.ocs("POST", f"{nc_app._session.ae_url}/{appcfg._url_suffix}", json=params)
     assert not result["sensitive"]  # by default if sensitive value is unspecified it is False
     appcfg.delete("test_key")
     params = {"configKey": "test_key", "configValue": "123", "sensitive": True}
-    result = nc_app._session.ocs(method="POST", path=f"{nc_app._session.ae_url}/{appcfg._url_suffix}", json=params)
+    result = nc_app._session.ocs("POST", f"{nc_app._session.ae_url}/{appcfg._url_suffix}", json=params)
     assert result["configkey"] == "test_key"
     assert result["configvalue"] == "123"
     assert bool(result["sensitive"]) is True
     params.pop("sensitive")  # if we not specify value, AppEcosystem should not change it.
-    result = nc_app._session.ocs(method="POST", path=f"{nc_app._session.ae_url}/{appcfg._url_suffix}", json=params)
+    result = nc_app._session.ocs("POST", f"{nc_app._session.ae_url}/{appcfg._url_suffix}", json=params)
     assert result["configkey"] == "test_key"
     assert result["configvalue"] == "123"
     assert bool(result["sensitive"]) is True
     params["sensitive"] = False
-    result = nc_app._session.ocs(method="POST", path=f"{nc_app._session.ae_url}/{appcfg._url_suffix}", json=params)
+    result = nc_app._session.ocs("POST", f"{nc_app._session.ae_url}/{appcfg._url_suffix}", json=params)
     assert result["configkey"] == "test_key"
     assert result["configvalue"] == "123"
     assert bool(result["sensitive"]) is False

--- a/tests/actual_tests/logs_test.py
+++ b/tests/actual_tests/logs_test.py
@@ -41,11 +41,11 @@ def test_loglvl_less(nc_app):
     current_log_lvl = nc_app.capabilities["app_api"].get("loglevel", LogLvl.FATAL)
     if current_log_lvl == LogLvl.DEBUG:
         pytest.skip("Log lvl to low")
-    with mock.patch("tests.conftest.NC_APP._session._ocs") as _ocs:
+    with mock.patch("tests.conftest.NC_APP._session.ocs") as ocs:
         nc_app.log(int(current_log_lvl) - 1, "will not be sent")  # noqa
-        _ocs.assert_not_called()
+        ocs.assert_not_called()
         nc_app.log(current_log_lvl, "will be sent")
-        assert _ocs.call_count > 0
+        assert ocs.call_count > 0
 
 
 def test_log_without_app_api(nc_app):
@@ -56,7 +56,7 @@ def test_log_without_app_api(nc_app):
     patched_capabilities = {"capabilities": srv_capabilities, "version": srv_version}
     with (
         mock.patch.dict("tests.conftest.NC_APP._session._capabilities", patched_capabilities, clear=True),
-        mock.patch("tests.conftest.NC_APP._session._ocs") as _ocs,
+        mock.patch("tests.conftest.NC_APP._session.ocs") as ocs,
     ):
         nc_app.log(log_lvl, "will not be sent")
-        _ocs.assert_not_called()
+        ocs.assert_not_called()

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -2,6 +2,7 @@ import datetime
 import os
 
 import pytest
+from httpx import Request, Response
 
 from nc_py_api import Nextcloud, NextcloudApp, NextcloudException, ex_app
 from nc_py_api._deffered_error import DeferredError  # noqa
@@ -14,9 +15,9 @@ from nc_py_api._session import BasicConfig  # noqa
 def test_check_error(code):
     if 996 <= code <= 999:
         with pytest.raises(NextcloudException):
-            check_error(code)
+            check_error(Response(code, request=Request(method="GET", url="https://example")))
     else:
-        check_error(code)
+        check_error(Response(code, request=Request(method="GET", url="https://example")))
 
 
 def test_nc_exception_to_str():

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -61,18 +61,8 @@ def test_deffered_error():
 
 def test_response_headers(nc):
     old_headers = nc.response_headers
-    old_headers_dav = nc.response_headers_dav
     nc.users.get_user(nc.user)  # do not remove "nc.user" arguments, it helps to trigger response header updates.
     assert old_headers != nc.response_headers
-    assert old_headers_dav == nc.response_headers_dav
-
-
-def test_dav_response_headers(nc):
-    old_headers = nc.response_headers
-    old_headers_dav = nc.response_headers_dav
-    nc.files.listdir()
-    assert old_headers == nc.response_headers
-    assert old_headers_dav != nc.response_headers_dav
 
 
 def test_nc_iso_time_to_datetime():

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -58,10 +58,20 @@ def test_deffered_error():
         unknown_non_exist_module.some_class_or_func()
 
 
-def test_ocs_response_headers(nc):
+def test_response_headers(nc):
     old_headers = nc.response_headers
-    nc.users.get_user()
+    old_headers_dav = nc.response_headers_dav
+    nc.users.get_user(nc.user)  # do not remove "nc.user" arguments, it helps to trigger response header updates.
     assert old_headers != nc.response_headers
+    assert old_headers_dav == nc.response_headers_dav
+
+
+def test_dav_response_headers(nc):
+    old_headers = nc.response_headers
+    old_headers_dav = nc.response_headers_dav
+    nc.files.listdir()
+    assert old_headers == nc.response_headers
+    assert old_headers_dav != nc.response_headers_dav
 
 
 def test_nc_iso_time_to_datetime():

--- a/tests/actual_tests/talk_test.py
+++ b/tests/actual_tests/talk_test.py
@@ -4,7 +4,7 @@ from os import environ
 import pytest
 from PIL import Image
 
-from nc_py_api import Nextcloud, files, talk, talk_bot
+from nc_py_api import Nextcloud, NextcloudException, files, talk, talk_bot
 
 
 def test_conversation_create_delete(nc):
@@ -383,6 +383,8 @@ def test_conversation_avatar(nc_any):
         assert r.is_custom_avatar is True
         r = nc_any.talk.get_conversation_avatar(conversation, dark=True)
         assert isinstance(r, bytes)
+        with pytest.raises(NextcloudException):
+            nc_any.talk.get_conversation_avatar("not_exist_conversation")
     finally:
         nc_any.talk.delete_conversation(conversation)
 

--- a/tests/actual_tests/talk_test.py
+++ b/tests/actual_tests/talk_test.py
@@ -242,6 +242,7 @@ def test_list_bots(nc, nc_app):
         nc.talk.delete_conversation(conversation.token)
 
 
+@pytest.mark.skipif(environ.get("CI", None) is None, reason="run only on GitHub")
 @pytest.mark.require_nc(major=27, minor=1)
 def test_chat_bot_receive_message(nc_app):
     if nc_app.talk.bots_available is False:

--- a/tests/actual_tests/users_test.py
+++ b/tests/actual_tests/users_test.py
@@ -155,3 +155,5 @@ def test_avatars(nc):
     for i in (im, im_64, im_black, im_64_black):
         img = Image.open(BytesIO(i))
         img.load()
+    with pytest.raises(NextcloudException):
+        nc.users.get_avatar("not_existing_user")


### PR DESCRIPTION
_Because initially the project was written for a different AppAPI authentication, where all transmitted data was signed - there was a lot of unnecessary code left._

This pull request will cover it all, total refactoring and simplification of the code.

**After this, it will be possible to make public methods for communicating with Nextcloud, which would make it easier to connect third-party packages.**

**It is also necessary to clean up the code before adding asynchronous methods.**


Changes proposed in this pull request:

 * set `AUTHORIZATION-APP-API` header with help of `event_hook`
 * set default `timeout` during `httpx.adapter` creation
 * set `base_url` during `httpx.adapter` creation
 * download_directory_as_zip: directly call `session.adapter.stream` (removed `_session.get_stream`)
 * all DAV methods now directly call `_session.adapter_dav.XXX` (removed `_session.dav` / `_session.dav_stream`)
 * removed `_session.request` and `_sessions.request_json` - instead directly call `session.adapter`
 * `response_headers` are now set with help of `httpx.event_hooks`
 * other internal code refactoring
 