### PR TITLE
drop python 3.9 support

### DIFF
--- a/benchmarks/aa_overhead_dav_download.py
+++ b/benchmarks/aa_overhead_dav_download.py
@@ -1,7 +1,7 @@
 from getpass import getuser
 from random import randbytes
 from time import perf_counter
-from typing import Any, Union
+from typing import Any
 
 import matplotlib.pyplot as plt
 from aa_overhead_common import measure_overhead, os_id
@@ -12,7 +12,7 @@ ITERS = 30
 CACHE_SESS = False
 
 
-def measure_download_1mb(nc_obj: Union[Nextcloud, NextcloudApp]) -> [Any, float]:
+def measure_download_1mb(nc_obj: Nextcloud | NextcloudApp) -> [Any, float]:
     __result = None
     small_file_name = "1Mb.bin"
     small_file = randbytes(1024 * 1024)

--- a/benchmarks/aa_overhead_dav_download_stream.py
+++ b/benchmarks/aa_overhead_dav_download_stream.py
@@ -2,7 +2,7 @@ from getpass import getuser
 from io import BytesIO
 from random import randbytes
 from time import perf_counter
-from typing import Any, Union
+from typing import Any
 
 import matplotlib.pyplot as plt
 from aa_overhead_common import measure_overhead, os_id
@@ -13,7 +13,7 @@ ITERS = 10
 CACHE_SESS = False
 
 
-def measure_download_100mb(nc_obj: Union[Nextcloud, NextcloudApp]) -> [Any, float]:
+def measure_download_100mb(nc_obj: Nextcloud | NextcloudApp) -> [Any, float]:
     __result = None
     medium_file_name = "100Mb.bin"
     medium_file = BytesIO()

--- a/benchmarks/aa_overhead_dav_upload.py
+++ b/benchmarks/aa_overhead_dav_upload.py
@@ -1,7 +1,7 @@
 from getpass import getuser
 from random import randbytes
 from time import perf_counter
-from typing import Any, Union
+from typing import Any
 
 import matplotlib.pyplot as plt
 from aa_overhead_common import measure_overhead, os_id
@@ -12,7 +12,7 @@ ITERS = 30
 CACHE_SESS = False
 
 
-def measure_upload_1mb(nc_obj: Union[Nextcloud, NextcloudApp]) -> [Any, float]:
+def measure_upload_1mb(nc_obj: Nextcloud | NextcloudApp) -> [Any, float]:
     __result = None
     small_file_name = "1Mb.bin"
     small_file = randbytes(1024 * 1024)

--- a/benchmarks/aa_overhead_dav_upload_stream.py
+++ b/benchmarks/aa_overhead_dav_upload_stream.py
@@ -2,7 +2,7 @@ from getpass import getuser
 from io import BytesIO
 from random import randbytes
 from time import perf_counter
-from typing import Any, Union
+from typing import Any
 
 import matplotlib.pyplot as plt
 from aa_overhead_common import measure_overhead, os_id
@@ -13,7 +13,7 @@ ITERS = 10
 CACHE_SESS = False
 
 
-def measure_upload_100mb(nc_obj: Union[Nextcloud, NextcloudApp]) -> [Any, float]:
+def measure_upload_100mb(nc_obj: Nextcloud | NextcloudApp) -> [Any, float]:
     __result = None
     medium_file_name = "100Mb.bin"
     medium_file = BytesIO()

--- a/benchmarks/aa_overhead_ocs.py
+++ b/benchmarks/aa_overhead_ocs.py
@@ -1,6 +1,6 @@
 from getpass import getuser
 from time import perf_counter
-from typing import Any, Union
+from typing import Any
 
 import matplotlib.pyplot as plt
 from aa_overhead_common import measure_overhead, os_id
@@ -11,7 +11,7 @@ ITERS = 100
 CACHE_SESS = False
 
 
-def measure_get_details(nc_obj: Union[Nextcloud, NextcloudApp]) -> [Any, float]:
+def measure_get_details(nc_obj: Nextcloud | NextcloudApp) -> [Any, float]:
     __result = None
     start_time = perf_counter()
     for _ in range(ITERS):

--- a/benchmarks/conf.py
+++ b/benchmarks/conf.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from nc_py_api import Nextcloud, NextcloudApp
 
 NC_CFGS = {
@@ -39,19 +37,19 @@ NC_CFGS = {
 }
 
 
-def init_nc(url, cfg) -> Optional[Nextcloud]:
+def init_nc(url, cfg) -> Nextcloud | None:
     if cfg.get("nc_auth_user", "") and cfg.get("nc_auth_pass", ""):
         return Nextcloud(nc_auth_user=cfg["nc_auth_user"], nc_auth_pass=cfg["nc_auth_pass"], nextcloud_url=url)
     return None
 
 
-def init_nc_by_app_pass(url, cfg) -> Optional[Nextcloud]:
+def init_nc_by_app_pass(url, cfg) -> Nextcloud | None:
     if cfg.get("nc_auth_user", "") and cfg.get("nc_auth_app_pass", ""):
         return Nextcloud(nc_auth_user=cfg["nc_auth_user"], nc_auth_pass=cfg["nc_auth_app_pass"], nextcloud_url=url)
     return None
 
 
-def init_nc_app(url, cfg) -> Optional[NextcloudApp]:
+def init_nc_app(url, cfg) -> NextcloudApp | None:
     if cfg.get("secret", "") and cfg.get("app_id", ""):
         return NextcloudApp(
             app_id=cfg["app_id"],

--- a/nc_py_api/_misc.py
+++ b/nc_py_api/_misc.py
@@ -5,9 +5,9 @@ For internal use, prototypes can change between versions.
 
 import secrets
 from base64 import b64decode
+from collections.abc import Callable
 from datetime import datetime, timezone
 from string import ascii_letters, digits
-from typing import Callable, Union
 
 from ._exceptions import NextcloudMissingCapabilities
 
@@ -28,7 +28,7 @@ def clear_from_params_empty(keys: list[str], params: dict) -> None:
             params.pop(key)
 
 
-def require_capabilities(capabilities: Union[str, list[str]], srv_capabilities: dict) -> None:
+def require_capabilities(capabilities: str | list[str], srv_capabilities: dict) -> None:
     """Checks for capabilities and raises an exception if any of them are missing."""
     result = check_capabilities(capabilities, srv_capabilities)
     if result:
@@ -52,7 +52,7 @@ def __check_sub_capability(split_capabilities: list[str], srv_capabilities: dict
     return True
 
 
-def check_capabilities(capabilities: Union[str, list[str]], srv_capabilities: dict) -> list[str]:
+def check_capabilities(capabilities: str | list[str], srv_capabilities: dict) -> list[str]:
     """Checks for capabilities and returns a list of missing ones."""
     if isinstance(capabilities, str):
         capabilities = [capabilities]

--- a/nc_py_api/_preferences_ex.py
+++ b/nc_py_api/_preferences_ex.py
@@ -1,7 +1,6 @@
 """Nextcloud API for working with apps V2's storage w/wo user context(table oc_appconfig_ex/oc_preferences_ex)."""
 
 import dataclasses
-import typing
 
 from ._exceptions import NextcloudExceptionNotFound
 from ._misc import require_capabilities
@@ -26,7 +25,7 @@ class _BasicAppCfgPref:
     def __init__(self, session: NcSessionBasic):
         self._session = session
 
-    def get_value(self, key: str, default=None) -> typing.Optional[str]:
+    def get_value(self, key: str, default=None) -> str | None:
         """Returns the value of the key, if found, or the specified default value."""
         if not key:
             raise ValueError("`key` parameter can not be empty")
@@ -47,7 +46,7 @@ class _BasicAppCfgPref:
         results = self._session.ocs("POST", f"{self._session.ae_url}/{self._url_suffix}/get-values", json=data)
         return [CfgRecord(i) for i in results]
 
-    def delete(self, keys: typing.Union[str, list[str]], not_fail=True) -> None:
+    def delete(self, keys: str | list[str], not_fail=True) -> None:
         """Deletes config/preference entries by the provided keys."""
         if isinstance(keys, str):
             keys = [keys]
@@ -82,7 +81,7 @@ class AppConfigExAPI(_BasicAppCfgPref):
 
     _url_suffix = "ex-app/config"
 
-    def set_value(self, key: str, value: str, sensitive: typing.Optional[bool] = None) -> None:
+    def set_value(self, key: str, value: str, sensitive: bool | None = None) -> None:
         """Sets a value and if specified the sensitive flag for a key.
 
         .. note:: A sensitive flag ensures key values are truncated in Nextcloud logs.

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -49,9 +49,9 @@ class ServerVersion(typing.TypedDict):
 @dataclass
 class RuntimeOptions:
     xdebug_session: str
-    timeout: typing.Optional[int]
-    timeout_dav: typing.Optional[int]
-    _nc_cert: typing.Union[str, bool]
+    timeout: int | None
+    timeout_dav: int | None
+    _nc_cert: str | bool
     upload_chunk_v2: bool
 
     def __init__(self, **kwargs):
@@ -62,7 +62,7 @@ class RuntimeOptions:
         self.upload_chunk_v2 = kwargs.get("chunked_upload_v2", options.CHUNKED_UPLOAD_V2)
 
     @property
-    def nc_cert(self) -> typing.Union[str, bool]:
+    def nc_cert(self) -> str | bool:
         return self._nc_cert
 
 
@@ -158,9 +158,9 @@ class NcSessionBasic(ABC):
         method: str,
         path: str,
         *,
-        content: typing.Optional[typing.Union[bytes, str, typing.Iterable[bytes], typing.AsyncIterable[bytes]]] = None,
-        json: typing.Optional[typing.Union[dict, list]] = None,
-        params: typing.Optional[dict] = None,
+        content: bytes | str | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
+        json: dict | list | None = None,
+        params: dict | None = None,
         **kwargs,
     ):
         self.init_adapter()

--- a/nc_py_api/_talk_api.py
+++ b/nc_py_api/_talk_api.py
@@ -1,7 +1,6 @@
 """Nextcloud Talk API implementation."""
 
 import hashlib
-import typing
 
 from ._exceptions import check_error
 from ._misc import (
@@ -51,7 +50,7 @@ class _TalkAPI:
         return not check_capabilities("spreed.features.bots-v1", self._session.capabilities)
 
     def get_user_conversations(
-        self, no_status_update: bool = True, include_status: bool = False, modified_since: typing.Union[int, bool] = 0
+        self, no_status_update: bool = True, include_status: bool = False, modified_since: int | bool = 0
     ) -> list[Conversation]:
         """Returns the list of the user's conversations.
 
@@ -78,9 +77,7 @@ class _TalkAPI:
         self._update_config_sha()
         return [Conversation(i) for i in result]
 
-    def list_participants(
-        self, conversation: typing.Union[Conversation, str], include_status: bool = False
-    ) -> list[Participant]:
+    def list_participants(self, conversation: Conversation | str, include_status: bool = False) -> list[Participant]:
         """Returns a list of conversation participants.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -127,7 +124,7 @@ class _TalkAPI:
         clear_from_params_empty(["invite", "source", "roomName", "objectType", "objectId"], params)
         return Conversation(self._session.ocs("POST", self._ep_base + "/api/v4/room", json=params))
 
-    def rename_conversation(self, conversation: typing.Union[Conversation, str], new_name: str) -> None:
+    def rename_conversation(self, conversation: Conversation | str, new_name: str) -> None:
         """Renames a conversation.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -136,7 +133,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         self._session.ocs("PUT", self._ep_base + f"/api/v4/room/{token}", params={"roomName": new_name})
 
-    def set_conversation_description(self, conversation: typing.Union[Conversation, str], description: str) -> None:
+    def set_conversation_description(self, conversation: Conversation | str, description: str) -> None:
         """Sets conversation description.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -147,7 +144,7 @@ class _TalkAPI:
             "PUT", self._ep_base + f"/api/v4/room/{token}/description", params={"description": description}
         )
 
-    def set_conversation_fav(self, conversation: typing.Union[Conversation, str], favorite: bool) -> None:
+    def set_conversation_fav(self, conversation: Conversation | str, favorite: bool) -> None:
         """Changes conversation **favorite** state.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -156,7 +153,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         self._session.ocs("POST" if favorite else "DELETE", self._ep_base + f"/api/v4/room/{token}/favorite")
 
-    def set_conversation_password(self, conversation: typing.Union[Conversation, str], password: str) -> None:
+    def set_conversation_password(self, conversation: Conversation | str, password: str) -> None:
         """Sets password for a conversation.
 
         Currently, it is only allowed to have a password for ``public`` conversations.
@@ -169,7 +166,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         self._session.ocs("PUT", self._ep_base + f"/api/v4/room/{token}/password", params={"password": password})
 
-    def set_conversation_readonly(self, conversation: typing.Union[Conversation, str], read_only: bool) -> None:
+    def set_conversation_readonly(self, conversation: Conversation | str, read_only: bool) -> None:
         """Changes conversation **read_only** state.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -178,7 +175,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         self._session.ocs("PUT", self._ep_base + f"/api/v4/room/{token}/read-only", params={"state": int(read_only)})
 
-    def set_conversation_public(self, conversation: typing.Union[Conversation, str], public: bool) -> None:
+    def set_conversation_public(self, conversation: Conversation | str, public: bool) -> None:
         """Changes conversation **public** state.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -187,9 +184,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         self._session.ocs("POST" if public else "DELETE", self._ep_base + f"/api/v4/room/{token}/public")
 
-    def set_conversation_notify_lvl(
-        self, conversation: typing.Union[Conversation, str], new_lvl: NotificationLevel
-    ) -> None:
+    def set_conversation_notify_lvl(self, conversation: Conversation | str, new_lvl: NotificationLevel) -> None:
         """Sets new notification level for user in the conversation.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -198,14 +193,14 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         self._session.ocs("POST", self._ep_base + f"/api/v4/room/{token}/notify", json={"level": int(new_lvl)})
 
-    def get_conversation_by_token(self, conversation: typing.Union[Conversation, str]) -> Conversation:
+    def get_conversation_by_token(self, conversation: Conversation | str) -> Conversation:
         """Gets conversation by token."""
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         result = self._session.ocs("GET", self._ep_base + f"/api/v4/room/{token}")
         self._update_config_sha()
         return Conversation(result)
 
-    def delete_conversation(self, conversation: typing.Union[Conversation, str]) -> None:
+    def delete_conversation(self, conversation: Conversation | str) -> None:
         """Deletes a conversation.
 
         .. note:: Deleting a conversation that is the parent of breakout rooms, will also delete them.
@@ -217,7 +212,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         self._session.ocs("DELETE", self._ep_base + f"/api/v4/room/{token}")
 
-    def leave_conversation(self, conversation: typing.Union[Conversation, str]) -> None:
+    def leave_conversation(self, conversation: Conversation | str) -> None:
         """Removes yourself from the conversation.
 
         .. note:: When the participant is a moderator or owner and there are no other moderators or owners left,
@@ -231,8 +226,8 @@ class _TalkAPI:
     def send_message(
         self,
         message: str,
-        conversation: typing.Union[Conversation, str] = "",
-        reply_to_message: typing.Union[int, TalkMessage] = 0,
+        conversation: Conversation | str = "",
+        reply_to_message: int | TalkMessage = 0,
         silent: bool = False,
         actor_display_name: str = "",
     ) -> TalkMessage:
@@ -262,11 +257,7 @@ class _TalkAPI:
         r = self._session.ocs("POST", self._ep_base + f"/api/v1/chat/{token}", json=params)
         return TalkMessage(r)
 
-    def send_file(
-        self,
-        path: typing.Union[str, FsNode],
-        conversation: typing.Union[Conversation, str] = "",
-    ) -> tuple[Share, str]:
+    def send_file(self, path: str | FsNode, conversation: Conversation | str = "") -> tuple[Share, str]:
         require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         reference_id = hashlib.sha256(random_string(32).encode("UTF-8")).hexdigest()
@@ -281,7 +272,7 @@ class _TalkAPI:
 
     def receive_messages(
         self,
-        conversation: typing.Union[Conversation, str],
+        conversation: Conversation | str,
         look_in_future: bool = False,
         limit: int = 100,
         timeout: int = 30,
@@ -305,9 +296,7 @@ class _TalkAPI:
         result = self._session.ocs("GET", self._ep_base + f"/api/v1/chat/{token}", params=params)
         return [TalkFileMessage(i, self._session.user) if i["message"] == "{file}" else TalkMessage(i) for i in result]
 
-    def delete_message(
-        self, message: typing.Union[TalkMessage, str], conversation: typing.Union[Conversation, str] = ""
-    ) -> TalkMessage:
+    def delete_message(self, message: TalkMessage | str, conversation: Conversation | str = "") -> TalkMessage:
         """Delete a chat message.
 
         :param message: Message ID or :py:class:`~nc_py_api.talk.TalkMessage` to delete.
@@ -321,10 +310,7 @@ class _TalkAPI:
         return TalkMessage(result)
 
     def react_to_message(
-        self,
-        message: typing.Union[TalkMessage, str],
-        reaction: str,
-        conversation: typing.Union[Conversation, str] = "",
+        self, message: TalkMessage | str, reaction: str, conversation: Conversation | str = ""
     ) -> dict[str, list[MessageReactions]]:
         """React to a chat message.
 
@@ -345,10 +331,7 @@ class _TalkAPI:
         return {k: [MessageReactions(i) for i in v] for k, v in r.items()} if r else {}
 
     def delete_reaction(
-        self,
-        message: typing.Union[TalkMessage, str],
-        reaction: str,
-        conversation: typing.Union[Conversation, str] = "",
+        self, message: TalkMessage | str, reaction: str, conversation: Conversation | str = ""
     ) -> dict[str, list[MessageReactions]]:
         """Remove reaction from a chat message.
 
@@ -367,10 +350,7 @@ class _TalkAPI:
         return {k: [MessageReactions(i) for i in v] for k, v in r.items()} if r else {}
 
     def get_message_reactions(
-        self,
-        message: typing.Union[TalkMessage, str],
-        reaction_filter: str = "",
-        conversation: typing.Union[Conversation, str] = "",
+        self, message: TalkMessage | str, reaction_filter: str = "", conversation: Conversation | str = ""
     ) -> dict[str, list[MessageReactions]]:
         """Get reactions information for a chat message.
 
@@ -391,7 +371,7 @@ class _TalkAPI:
         require_capabilities("spreed.features.bots-v1", self._session.capabilities)
         return [BotInfo(i) for i in self._session.ocs("GET", self._ep_base + "/api/v1/bot/admin")]
 
-    def conversation_list_bots(self, conversation: typing.Union[Conversation, str]) -> list[BotInfoBasic]:
+    def conversation_list_bots(self, conversation: Conversation | str) -> list[BotInfoBasic]:
         """Lists the bots that are enabled and can be enabled for the conversation.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -400,7 +380,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         return [BotInfoBasic(i) for i in self._session.ocs("GET", self._ep_base + f"/api/v1/bot/{token}")]
 
-    def enable_bot(self, conversation: typing.Union[Conversation, str], bot: typing.Union[BotInfoBasic, int]) -> None:
+    def enable_bot(self, conversation: Conversation | str, bot: BotInfoBasic | int) -> None:
         """Enable a bot for a conversation as a moderator.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -411,7 +391,7 @@ class _TalkAPI:
         bot_id = bot.bot_id if isinstance(bot, BotInfoBasic) else bot
         self._session.ocs("POST", self._ep_base + f"/api/v1/bot/{token}/{bot_id}")
 
-    def disable_bot(self, conversation: typing.Union[Conversation, str], bot: typing.Union[BotInfoBasic, int]) -> None:
+    def disable_bot(self, conversation: Conversation | str, bot: BotInfoBasic | int) -> None:
         """Disable a bot for a conversation as a moderator.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -424,7 +404,7 @@ class _TalkAPI:
 
     def create_poll(
         self,
-        conversation: typing.Union[Conversation, str],
+        conversation: Conversation | str,
         question: str,
         options: list[str],
         hidden_results: bool = True,
@@ -447,7 +427,7 @@ class _TalkAPI:
         }
         return Poll(self._session.ocs("POST", self._ep_base + f"/api/v1/poll/{token}", json=params), token)
 
-    def get_poll(self, poll: typing.Union[Poll, int], conversation: typing.Union[Conversation, str] = "") -> Poll:
+    def get_poll(self, poll: Poll | int, conversation: Conversation | str = "") -> Poll:
         """Get state or result of a poll.
 
         :param poll: Poll ID or :py:class:`~nc_py_api.talk.Poll`.
@@ -461,12 +441,7 @@ class _TalkAPI:
             token = conversation.token if isinstance(conversation, Conversation) else conversation
         return Poll(self._session.ocs("GET", self._ep_base + f"/api/v1/poll/{token}/{poll_id}"), token)
 
-    def vote_poll(
-        self,
-        options_ids: list[int],
-        poll: typing.Union[Poll, int],
-        conversation: typing.Union[Conversation, str] = "",
-    ) -> Poll:
+    def vote_poll(self, options_ids: list[int], poll: Poll | int, conversation: Conversation | str = "") -> Poll:
         """Vote on a poll.
 
         :param options_ids: The option IDs the participant wants to vote for.
@@ -484,7 +459,7 @@ class _TalkAPI:
         )
         return Poll(r, token)
 
-    def close_poll(self, poll: typing.Union[Poll, int], conversation: typing.Union[Conversation, str] = "") -> Poll:
+    def close_poll(self, poll: Poll | int, conversation: Conversation | str = "") -> Poll:
         """Close a poll.
 
         :param poll: Poll ID or :py:class:`~nc_py_api.talk.Poll`.
@@ -499,9 +474,7 @@ class _TalkAPI:
         return Poll(self._session.ocs("DELETE", self._ep_base + f"/api/v1/poll/{token}/{poll_id}"), token)
 
     def set_conversation_avatar(
-        self,
-        conversation: typing.Union[Conversation, str],
-        avatar: typing.Union[bytes, tuple[str, typing.Union[str, None]]],
+        self, conversation: Conversation | str, avatar: bytes | tuple[str, str | None]
     ) -> Conversation:
         """Set image or emoji as avatar for the conversation.
 
@@ -526,7 +499,7 @@ class _TalkAPI:
             )
         return Conversation(r)
 
-    def delete_conversation_avatar(self, conversation: typing.Union[Conversation, str]) -> Conversation:
+    def delete_conversation_avatar(self, conversation: Conversation | str) -> Conversation:
         """Delete conversation avatar.
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -535,7 +508,7 @@ class _TalkAPI:
         token = conversation.token if isinstance(conversation, Conversation) else conversation
         return Conversation(self._session.ocs("DELETE", self._ep_base + f"/api/v1/room/{token}/avatar"))
 
-    def get_conversation_avatar(self, conversation: typing.Union[Conversation, str], dark=False) -> bytes:
+    def get_conversation_avatar(self, conversation: Conversation | str, dark=False) -> bytes:
         """Get conversation avatar (binary).
 
         :param conversation: conversation token or :py:class:`~nc_py_api.talk.Conversation`.
@@ -549,7 +522,7 @@ class _TalkAPI:
         return response.content
 
     @staticmethod
-    def _get_token(message: typing.Union[TalkMessage, str], conversation: typing.Union[Conversation, str]) -> str:
+    def _get_token(message: TalkMessage | str, conversation: Conversation | str) -> str:
         if not conversation and not isinstance(message, TalkMessage):
             raise ValueError("Either specify 'conversation' or provide 'TalkMessage'.")
 

--- a/nc_py_api/activity.py
+++ b/nc_py_api/activity.py
@@ -2,7 +2,6 @@
 
 import dataclasses
 import datetime
-import typing
 
 from ._exceptions import NextcloudExceptionNotModified
 from ._misc import check_capabilities, nc_iso_time_to_datetime
@@ -154,8 +153,8 @@ class _ActivityAPI:
 
     def get_activities(
         self,
-        filter_id: typing.Union[ActivityFilter, str] = "",
-        since: typing.Union[int, bool] = 0,
+        filter_id: ActivityFilter | str = "",
+        since: int | bool = 0,
         limit: int = 50,
         object_type: str = "",
         object_id: int = 0,

--- a/nc_py_api/apps.py
+++ b/nc_py_api/apps.py
@@ -2,7 +2,6 @@
 
 import dataclasses
 import datetime
-import typing
 
 from ._misc import require_capabilities
 from ._session import NcSessionBasic
@@ -77,7 +76,7 @@ class _AppsAPI:
             raise ValueError("`app_id` parameter can not be empty")
         self._session.ocs("POST", f"{self._ep_base}/{app_id}")
 
-    def get_list(self, enabled: typing.Optional[bool] = None) -> list[str]:
+    def get_list(self, enabled: bool | None = None) -> list[str]:
         """Get the list of installed applications.
 
         :param enabled: filter to list all/only enabled/only disabled applications.

--- a/nc_py_api/ex_app/integration_fastapi.py
+++ b/nc_py_api/ex_app/integration_fastapi.py
@@ -54,11 +54,11 @@ def talk_bot_app(request: Request) -> TalkBotMessage:
 
 def set_handlers(
     fast_api_app: FastAPI,
-    enabled_handler: typing.Callable[[bool, NextcloudApp], typing.Union[str, typing.Awaitable[str]]],
-    heartbeat_handler: typing.Optional[typing.Callable[[], typing.Union[str, typing.Awaitable[str]]]] = None,
-    init_handler: typing.Optional[typing.Callable[[NextcloudApp], None]] = None,
-    models_to_fetch: typing.Optional[list[str]] = None,
-    models_download_params: typing.Optional[dict] = None,
+    enabled_handler: typing.Callable[[bool, NextcloudApp], str | typing.Awaitable[str]],
+    heartbeat_handler: typing.Callable[[], str | typing.Awaitable[str]] | None = None,
+    init_handler: typing.Callable[[NextcloudApp], None] | None = None,
+    models_to_fetch: list[str] | None = None,
+    models_download_params: dict | None = None,
     map_app_static: bool = True,
 ):
     """Defines handlers for the application.
@@ -133,7 +133,7 @@ def __map_app_static_folders(fast_api_app: FastAPI):
 
 def __fetch_models_task(
     nc: NextcloudApp,
-    init_handler: typing.Optional[typing.Callable[[NextcloudApp], None]],
+    init_handler: typing.Callable[[NextcloudApp], None] | None,
     models: list[str],
     params: dict[str, typing.Any],
 ) -> None:

--- a/nc_py_api/ex_app/misc.py
+++ b/nc_py_api/ex_app/misc.py
@@ -1,7 +1,6 @@
 """Different miscellaneous optimization/helper functions for the Nextcloud Applications."""
 
 import os
-import typing
 from sys import platform
 
 
@@ -26,7 +25,7 @@ def _get_app_cache_dir() -> str:
     return r
 
 
-def verify_version(finalize_update: bool = True) -> typing.Optional[tuple[str, str]]:
+def verify_version(finalize_update: bool = True) -> tuple[str, str] | None:
     """Returns tuple with an old version and new version or ``None`` if there was no update taken.
 
     :param finalize_update: Flag indicating whether update information should be updated.

--- a/nc_py_api/ex_app/ui/files_actions.py
+++ b/nc_py_api/ex_app/ui/files_actions.py
@@ -3,7 +3,6 @@
 import dataclasses
 import datetime
 import os
-import typing
 
 from pydantic import BaseModel
 
@@ -87,11 +86,11 @@ class UiActionFileInfo(BaseModel):
     """Last modified time"""
     userId: str
     """The ID of the user performing the action."""
-    shareOwner: typing.Optional[str]
+    shareOwner: str | None
     """If the object is shared, this is a display name of the share owner."""
-    shareOwnerId: typing.Optional[str]
+    shareOwnerId: str | None
     """If the object is shared, this is the owner ID of the share."""
-    instanceId: typing.Optional[str]
+    instanceId: str | None
     """Nextcloud instance ID."""
 
     def to_fs_node(self) -> FsNode:
@@ -150,7 +149,7 @@ class _UiFilesActionsAPI:
             if not not_fail:
                 raise e from None
 
-    def get_entry(self, name: str) -> typing.Optional[UiFileActionEntry]:
+    def get_entry(self, name: str) -> UiFileActionEntry | None:
         """Get information of the file action meny entry for current app."""
         require_capabilities("app_api", self._session.capabilities)
         try:

--- a/nc_py_api/ex_app/ui/resources.py
+++ b/nc_py_api/ex_app/ui/resources.py
@@ -1,7 +1,6 @@
 """API for adding scripts, styles, initial-states to the Nextcloud UI."""
 
 import dataclasses
-import typing
 
 from ..._exceptions import NextcloudExceptionNotFound
 from ..._misc import require_capabilities
@@ -40,7 +39,7 @@ class UiInitState(UiBase):
         return self._raw_data["key"]
 
     @property
-    def value(self) -> typing.Union[dict, list]:
+    def value(self) -> dict | list:
         """Object for the page(template)."""
         return self._raw_data["value"]
 
@@ -87,7 +86,7 @@ class _UiResources:
     def __init__(self, session: NcSessionApp):
         self._session = session
 
-    def set_initial_state(self, ui_type: str, name: str, key: str, value: typing.Union[dict, list]) -> None:
+    def set_initial_state(self, ui_type: str, name: str, key: str, value: dict | list) -> None:
         """Add or update initial state for the page(template)."""
         require_capabilities("app_api", self._session.capabilities)
         params = {
@@ -111,7 +110,7 @@ class _UiResources:
             if not not_fail:
                 raise e from None
 
-    def get_initial_state(self, ui_type: str, name: str, key: str) -> typing.Optional[UiInitState]:
+    def get_initial_state(self, ui_type: str, name: str, key: str) -> UiInitState | None:
         """Get information about initial state for the page(template) by object name."""
         require_capabilities("app_api", self._session.capabilities)
         try:
@@ -149,7 +148,7 @@ class _UiResources:
             if not not_fail:
                 raise e from None
 
-    def get_script(self, ui_type: str, name: str, path: str) -> typing.Optional[UiScript]:
+    def get_script(self, ui_type: str, name: str, path: str) -> UiScript | None:
         """Get information about script for the page(template) by object name."""
         require_capabilities("app_api", self._session.capabilities)
         try:
@@ -186,7 +185,7 @@ class _UiResources:
             if not not_fail:
                 raise e from None
 
-    def get_style(self, ui_type: str, name: str, path: str) -> typing.Optional[UiStyle]:
+    def get_style(self, ui_type: str, name: str, path: str) -> UiStyle | None:
         """Get information about style(css) for the page(template) by object name."""
         require_capabilities("app_api", self._session.capabilities)
         try:

--- a/nc_py_api/ex_app/ui/top_menu.py
+++ b/nc_py_api/ex_app/ui/top_menu.py
@@ -1,7 +1,6 @@
 """Nextcloud API for working with Top App menu."""
 
 import dataclasses
-import typing
 
 from ..._exceptions import NextcloudExceptionNotFound
 from ..._misc import require_capabilities
@@ -78,7 +77,7 @@ class _UiTopMenuAPI:
             if not not_fail:
                 raise e from None
 
-    def get_entry(self, name: str) -> typing.Optional[UiTopMenuEntry]:
+    def get_entry(self, name: str) -> UiTopMenuEntry | None:
         """Get information of the top meny entry for current app."""
         require_capabilities("app_api", self._session.capabilities)
         try:

--- a/nc_py_api/ex_app/uvicorn_fastapi.py
+++ b/nc_py_api/ex_app/uvicorn_fastapi.py
@@ -12,7 +12,7 @@ except ImportError as ex:
 
 
 def run_app(
-    uvicorn_app: typing.Union[typing.Callable, str, typing.Any],
+    uvicorn_app: typing.Callable | str | typing.Any,
     *args,
     **kwargs,
 ) -> None:

--- a/nc_py_api/files/__init__.py
+++ b/nc_py_api/files/__init__.py
@@ -4,7 +4,6 @@ import dataclasses
 import datetime
 import email.utils
 import enum
-import typing
 
 from .. import _misc
 
@@ -36,7 +35,7 @@ class FsNodeInfo:
             self.last_modified = kwargs.get("last_modified", datetime.datetime(1970, 1, 1))
         except (ValueError, TypeError):
             self.last_modified = datetime.datetime(1970, 1, 1)
-        self._trashbin: dict[str, typing.Union[str, int]] = {}
+        self._trashbin: dict[str, str | int] = {}
         for i in ("trashbin_filename", "trashbin_original_location", "trashbin_deletion_time"):
             if i in kwargs:
                 self._trashbin[i] = kwargs[i]
@@ -70,7 +69,7 @@ class FsNodeInfo:
         return self._last_modified
 
     @last_modified.setter
-    def last_modified(self, value: typing.Union[str, datetime.datetime]):
+    def last_modified(self, value: str | datetime.datetime):
         if isinstance(value, str):
             self._last_modified = email.utils.parsedate_to_datetime(value)
         else:

--- a/nc_py_api/files/sharing.py
+++ b/nc_py_api/files/sharing.py
@@ -1,7 +1,5 @@
 """Nextcloud API for working with the files shares."""
 
-import typing
-
 from .. import _misc, _session
 from . import FilePermissions, FsNode, Share, ShareType
 
@@ -19,9 +17,7 @@ class _FilesSharingAPI:
         """Returns True if the Nextcloud instance supports this feature, False otherwise."""
         return not _misc.check_capabilities("files_sharing.api_enabled", self._session.capabilities)
 
-    def get_list(
-        self, shared_with_me=False, reshares=False, subfiles=False, path: typing.Union[str, FsNode] = ""
-    ) -> list[Share]:
+    def get_list(self, shared_with_me=False, reshares=False, subfiles=False, path: str | FsNode = "") -> list[Share]:
         """Returns lists of shares.
 
         :param shared_with_me: Shares should be with the current user.
@@ -55,9 +51,9 @@ class _FilesSharingAPI:
 
     def create(
         self,
-        path: typing.Union[str, FsNode],
+        path: str | FsNode,
         share_type: ShareType,
-        permissions: typing.Optional[FilePermissions] = None,
+        permissions: FilePermissions | None = None,
         share_with: str = "",
         **kwargs,
     ) -> Share:
@@ -104,7 +100,7 @@ class _FilesSharingAPI:
             params["label"] = kwargs["label"]
         return Share(self._session.ocs("POST", f"{self._ep_base}/shares", params=params))
 
-    def update(self, share_id: typing.Union[int, Share], **kwargs) -> Share:
+    def update(self, share_id: int | Share, **kwargs) -> Share:
         """Updates the share options.
 
         :param share_id: ID of the Share to update.
@@ -130,7 +126,7 @@ class _FilesSharingAPI:
             params["label"] = kwargs["label"]
         return Share(self._session.ocs("PUT", f"{self._ep_base}/shares/{share_id}", params=params))
 
-    def delete(self, share_id: typing.Union[int, Share]) -> None:
+    def delete(self, share_id: int | Share) -> None:
         """Removes the given share.
 
         :param share_id: The Share object or an ID of the share.
@@ -143,13 +139,13 @@ class _FilesSharingAPI:
         """Returns all pending shares for current user."""
         return [Share(i) for i in self._session.ocs("GET", f"{self._ep_base}/shares/pending")]
 
-    def accept_share(self, share_id: typing.Union[int, Share]) -> None:
+    def accept_share(self, share_id: int | Share) -> None:
         """Accept pending share."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         share_id = share_id.share_id if isinstance(share_id, Share) else share_id
         self._session.ocs("POST", f"{self._ep_base}/pending/{share_id}")
 
-    def decline_share(self, share_id: typing.Union[int, Share]) -> None:
+    def decline_share(self, share_id: int | Share) -> None:
         """Decline pending share."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         share_id = share_id.share_id if isinstance(share_id, Share) else share_id
@@ -160,7 +156,7 @@ class _FilesSharingAPI:
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         return [Share(i) for i in self._session.ocs("GET", f"{self._ep_base}/deletedshares")]
 
-    def undelete(self, share_id: typing.Union[int, Share]) -> None:
+    def undelete(self, share_id: int | Share) -> None:
         """Undelete a deleted share."""
         _misc.require_capabilities("files_sharing.api_enabled", self._session.capabilities)
         share_id = share_id.share_id if isinstance(share_id, Share) else share_id

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -1,7 +1,6 @@
 """Nextcloud class providing access to all API endpoints."""
 
 from abc import ABC
-from typing import Optional, Union
 
 from fastapi import Request
 from httpx import Headers as HttpxHeaders
@@ -78,7 +77,7 @@ class _NextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         """Returns dictionary with the server version."""
         return self._session.nc_version
 
-    def check_capabilities(self, capabilities: Union[str, list[str]]) -> list[str]:
+    def check_capabilities(self, capabilities: str | list[str]) -> list[str]:
         """Returns the list with missing capabilities if any.
 
         :param capabilities: one or more features to check for.
@@ -98,7 +97,7 @@ class _NextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         return self._session.response_headers
 
     @property
-    def theme(self) -> Optional[ThemingInfo]:
+    def theme(self) -> ThemingInfo | None:
         """Returns Theme information."""
         return get_parsed_theme(self.capabilities["theming"]) if "theming" in self.capabilities else None
 

--- a/nc_py_api/notes.py
+++ b/nc_py_api/notes.py
@@ -109,10 +109,10 @@ class _NotesAPI:
 
     def get_list(
         self,
-        category: typing.Optional[str] = None,
-        modified_since: typing.Optional[int] = None,
-        limit: typing.Optional[int] = None,
-        cursor: typing.Optional[str] = None,
+        category: str | None = None,
+        modified_since: int | None = None,
+        limit: int | None = None,
+        cursor: str | None = None,
         no_content: bool = False,
         etag: bool = False,
     ) -> list[Note]:
@@ -157,10 +157,10 @@ class _NotesAPI:
     def create(
         self,
         title: str,
-        content: typing.Optional[str] = None,
-        category: typing.Optional[str] = None,
-        favorite: typing.Optional[bool] = None,
-        last_modified: typing.Optional[typing.Union[int, str, datetime.datetime]] = None,
+        content: str | None = None,
+        category: str | None = None,
+        favorite: bool | None = None,
+        last_modified: int | str | datetime.datetime | None = None,
     ) -> Note:
         """Create new Note."""
         require_capabilities("notes", self._session.capabilities)
@@ -177,10 +177,10 @@ class _NotesAPI:
     def update(
         self,
         note: Note,
-        title: typing.Optional[str] = None,
-        content: typing.Optional[str] = None,
-        category: typing.Optional[str] = None,
-        favorite: typing.Optional[bool] = None,
+        title: str | None = None,
+        content: str | None = None,
+        category: str | None = None,
+        favorite: bool | None = None,
         overwrite: bool = False,
     ) -> Note:
         """Updates Note.
@@ -204,7 +204,7 @@ class _NotesAPI:
             )
         )
 
-    def delete(self, note: typing.Union[int, Note]) -> None:
+    def delete(self, note: int | Note) -> None:
         """Deletes a Note.
 
         :param note: note id or :py:class:`~nc_py_api.notes.Note`.
@@ -219,7 +219,7 @@ class _NotesAPI:
         r = self.__response_to_json(self._session.adapter.get(self._ep_base + "/settings"))
         return {"notes_path": r["notesPath"], "file_suffix": r["fileSuffix"]}
 
-    def set_settings(self, notes_path: typing.Optional[str] = None, file_suffix: typing.Optional[str] = None) -> None:
+    def set_settings(self, notes_path: str | None = None, file_suffix: str | None = None) -> None:
         """Change specified setting(s)."""
         if notes_path is None and file_suffix is None:
             raise ValueError("No setting to change.")

--- a/nc_py_api/notifications.py
+++ b/nc_py_api/notifications.py
@@ -2,7 +2,6 @@
 
 import dataclasses
 import datetime
-import typing
 
 from ._misc import (
     check_capabilities,
@@ -94,8 +93,8 @@ class _NotificationsAPI:
         self,
         subject: str,
         message: str = "",
-        subject_params: typing.Optional[dict] = None,
-        message_params: typing.Optional[dict] = None,
+        subject_params: dict | None = None,
+        message_params: dict | None = None,
         link: str = "",
     ) -> str:
         """Create a Notification for the current user and returns it's ObjectID.
@@ -138,7 +137,7 @@ class _NotificationsAPI:
         require_capabilities("notifications", self._session.capabilities)
         return Notification(self._session.ocs("GET", f"{self._ep_base}/{notification_id}"))
 
-    def by_object_id(self, object_id: str) -> typing.Optional[Notification]:
+    def by_object_id(self, object_id: str) -> Notification | None:
         """Returns Notification if any by its object ID.
 
         .. note:: this method is a temporary workaround until `create` can return `notification_id`.

--- a/nc_py_api/options.py
+++ b/nc_py_api/options.py
@@ -4,7 +4,6 @@ Each setting only affects newly created instances of **Nextcloud**/**NextcloudAp
 Specifying options in **kwargs** has higher priority than this.
 """
 
-import typing
 from os import environ
 
 from dotenv import load_dotenv
@@ -14,21 +13,21 @@ load_dotenv()
 XDEBUG_SESSION = environ.get("XDEBUG_SESSION", "")
 """Dev option, for debugging PHP code."""
 
-NPA_TIMEOUT: typing.Optional[int]
+NPA_TIMEOUT: int | None
 """Default timeout for OCS API calls. Set to ``None`` to disable timeouts for development."""
 try:
     NPA_TIMEOUT = int(environ.get("NPA_TIMEOUT", 30))
 except (TypeError, ValueError):
     NPA_TIMEOUT = None
 
-NPA_TIMEOUT_DAV: typing.Optional[int]
+NPA_TIMEOUT_DAV: int | None
 """File operations timeout, usually it is OCS timeout multiplied by 3."""
 try:
     NPA_TIMEOUT_DAV = int(environ.get("NPA_TIMEOUT_DAV", 30 * 3))
 except (TypeError, ValueError):
     NPA_TIMEOUT_DAV = None
 
-NPA_NC_CERT: typing.Union[bool, str]
+NPA_NC_CERT: bool | str
 """Option to enable/disable Nextcloud certificate verification.
 
 SSL certificates (a.k.a CA bundle) used to  verify the identity of requested hosts. Either **True** (default CA bundle),

--- a/nc_py_api/talk.py
+++ b/nc_py_api/talk.py
@@ -4,7 +4,6 @@ import dataclasses
 import datetime
 import enum
 import os
-import typing
 
 from . import files as _files
 
@@ -568,7 +567,7 @@ class Conversation(_TalkUserStatus):
         return self._raw_data["lastCommonReadMessage"]
 
     @property
-    def last_message(self) -> typing.Optional[TalkMessage]:
+    def last_message(self) -> TalkMessage | None:
         """Last message in a conversation if available, otherwise ``empty``.
 
         .. note:: Even when given, the message will not contain the ``parent`` or ``reactionsSelf``
@@ -625,7 +624,7 @@ class Conversation(_TalkUserStatus):
         return CallRecordingStatus(self._raw_data.get("callRecording", CallRecordingStatus.NO_RECORDING))
 
     @property
-    def status_clear_at(self) -> typing.Optional[int]:
+    def status_clear_at(self) -> int | None:
         """Unix Timestamp representing the time to clear the status.
 
         .. note:: Available only for ``one-to-one`` conversations.
@@ -760,7 +759,7 @@ class BotInfo(BotInfoBasic):
         return self._raw_data["last_error_date"]
 
     @property
-    def last_error_message(self) -> typing.Optional[str]:
+    def last_error_message(self) -> str | None:
         """The last exception message or error response information when trying to reach the bot."""
         return self._raw_data["last_error_message"]
 

--- a/nc_py_api/talk_bot.py
+++ b/nc_py_api/talk_bot.py
@@ -111,7 +111,7 @@ class TalkBot:
             nc.unregister_talk_bot(self.callback_url)
 
     def send_message(
-        self, message: str, reply_to_message: typing.Union[int, TalkBotMessage], silent: bool = False, token: str = ""
+        self, message: str, reply_to_message: int | TalkBotMessage, silent: bool = False, token: str = ""
     ) -> tuple[httpx.Response, str]:
         """Send a message and returns a "reference string" to identify the message again in a "get messages" request.
 
@@ -138,9 +138,7 @@ class TalkBot:
         }
         return self._sign_send_request("POST", f"/{token}/message", params, message), reference_id
 
-    def react_to_message(
-        self, message: typing.Union[int, TalkBotMessage], reaction: str, token: str = ""
-    ) -> httpx.Response:
+    def react_to_message(self, message: int | TalkBotMessage, reaction: str, token: str = "") -> httpx.Response:
         """React to a message.
 
         :param message: Message ID or :py:class:`~nc_py_api.talk_bot.TalkBotMessage` to react to.
@@ -159,9 +157,7 @@ class TalkBot:
         }
         return self._sign_send_request("POST", f"/{token}/reaction/{message_id}", params, reaction)
 
-    def delete_reaction(
-        self, message: typing.Union[int, TalkBotMessage], reaction: str, token: str = ""
-    ) -> httpx.Response:
+    def delete_reaction(self, message: int | TalkBotMessage, reaction: str, token: str = "") -> httpx.Response:
         """Removes reaction from a message.
 
         :param message: Message ID or :py:class:`~nc_py_api.talk_bot.TalkBotMessage` to remove reaction from.
@@ -204,7 +200,7 @@ class TalkBot:
         )
 
 
-def get_bot_secret(callback_url: str) -> typing.Union[bytes, None]:
+def get_bot_secret(callback_url: str) -> bytes | None:
     """Returns the bot's secret from an environment variable or from the application's configuration on the server."""
     sha_1 = hashlib.sha1(usedforsecurity=False)
     string_to_hash = os.environ["APP_ID"] + "_" + callback_url

--- a/nc_py_api/user_status.py
+++ b/nc_py_api/user_status.py
@@ -14,7 +14,7 @@ class ClearAt:
 
     clear_type: str
     """Possible values: ``period``, ``end-of``"""
-    time: typing.Union[str, int]
+    time: str | int
     """Depending of ``type`` it can be number of seconds relative to ``now`` or one of the next values: ``day``"""
 
     def __init__(self, raw_data: dict):
@@ -32,7 +32,7 @@ class PredefinedStatus:
     """Icon in string(UTF) format"""
     message: str
     """The message defined for this status. It is translated, so it depends on the user's language setting."""
-    clear_at: typing.Optional[ClearAt]
+    clear_at: ClearAt | None
     """When the default, if not override, the predefined status will be cleared."""
 
     def __init__(self, raw_status: dict):
@@ -68,7 +68,7 @@ class UserStatus:
         return self._raw_data.get("icon", "")
 
     @property
-    def status_clear_at(self) -> typing.Optional[int]:
+    def status_clear_at(self) -> int | None:
         """Unix Timestamp representing the time to clear the status."""
         return self._raw_data.get("clearAt", None)
 
@@ -86,7 +86,7 @@ class CurrentUserStatus(UserStatus):
     """Information about current user status."""
 
     @property
-    def status_id(self) -> typing.Optional[str]:
+    def status_id(self) -> str | None:
         """ID of the predefined status."""
         return self._raw_data["messageId"]
 
@@ -120,7 +120,7 @@ class _UserStatusAPI:
         """Returns True if the Nextcloud instance supports this feature, False otherwise."""
         return not check_capabilities("user_status.enabled", self._session.capabilities)
 
-    def get_list(self, limit: typing.Optional[int] = None, offset: typing.Optional[int] = None) -> list[UserStatus]:
+    def get_list(self, limit: int | None = None, offset: int | None = None) -> list[UserStatus]:
         """Returns statuses for all users."""
         require_capabilities("user_status.enabled", self._session.capabilities)
         data = kwargs_to_params(["limit", "offset"], limit=limit, offset=offset)
@@ -132,7 +132,7 @@ class _UserStatusAPI:
         require_capabilities("user_status.enabled", self._session.capabilities)
         return CurrentUserStatus(self._session.ocs("GET", f"{self._ep_base}/user_status"))
 
-    def get(self, user_id: str) -> typing.Optional[UserStatus]:
+    def get(self, user_id: str) -> UserStatus | None:
         """Returns the user status for the specified user."""
         require_capabilities("user_status.enabled", self._session.capabilities)
         try:
@@ -157,7 +157,7 @@ class _UserStatusAPI:
         if self._session.nc_version["major"] < 27:
             return
         require_capabilities("user_status.enabled", self._session.capabilities)
-        params: dict[str, typing.Union[int, str]] = {"messageId": status_id}
+        params: dict[str, int | str] = {"messageId": status_id}
         if clear_at:
             params["clearAt"] = clear_at
         self._session.ocs("PUT", f"{self._ep_base}/user_status/message/predefined", params=params)
@@ -167,7 +167,7 @@ class _UserStatusAPI:
         require_capabilities("user_status.enabled", self._session.capabilities)
         self._session.ocs("PUT", f"{self._ep_base}/user_status/status", params={"statusType": value})
 
-    def set_status(self, message: typing.Optional[str] = None, clear_at: int = 0, status_icon: str = "") -> None:
+    def set_status(self, message: str | None = None, clear_at: int = 0, status_icon: str = "") -> None:
         """Sets current user status.
 
         :param message: Message text to set in the status.
@@ -180,14 +180,14 @@ class _UserStatusAPI:
             return
         if status_icon:
             require_capabilities("user_status.supports_emoji", self._session.capabilities)
-        params: dict[str, typing.Union[int, str]] = {"message": message}
+        params: dict[str, int | str] = {"message": message}
         if clear_at:
             params["clearAt"] = clear_at
         if status_icon:
             params["statusIcon"] = status_icon
         self._session.ocs("PUT", f"{self._ep_base}/user_status/message/custom", params=params)
 
-    def get_backup_status(self, user_id: str = "") -> typing.Optional[UserStatus]:
+    def get_backup_status(self, user_id: str = "") -> UserStatus | None:
         """Get the backup status of the user if any."""
         require_capabilities("user_status.enabled", self._session.capabilities)
         user_id = user_id if user_id else self._session.user
@@ -195,7 +195,7 @@ class _UserStatusAPI:
             raise ValueError("user_id can not be empty.")
         return self.get(f"_{user_id}")
 
-    def restore_backup_status(self, status_id: str) -> typing.Optional[CurrentUserStatus]:
+    def restore_backup_status(self, status_id: str) -> CurrentUserStatus | None:
         """Restores the backup state as current for the current user."""
         require_capabilities("user_status.enabled", self._session.capabilities)
         require_capabilities("user_status.restore", self._session.capabilities)

--- a/nc_py_api/users.py
+++ b/nc_py_api/users.py
@@ -167,9 +167,7 @@ class _UsersAPI:
     def __init__(self, session: NcSessionBasic):
         self._session = session
 
-    def get_list(
-        self, mask: typing.Optional[str] = "", limit: typing.Optional[int] = None, offset: typing.Optional[int] = None
-    ) -> list[str]:
+    def get_list(self, mask: str | None = "", limit: int | None = None, offset: int | None = None) -> list[str]:
         """Returns list of user IDs."""
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
         response_data = self._session.ocs("GET", self._ep_base, params=data)
@@ -179,7 +177,7 @@ class _UsersAPI:
         """Returns detailed user information."""
         return UserInfo(self._session.ocs("GET", f"{self._ep_base}/{user_id}" if user_id else "/ocs/v1.php/cloud/user"))
 
-    def create(self, user_id: str, display_name: typing.Optional[str] = None, **kwargs) -> None:
+    def create(self, user_id: str, display_name: str | None = None, **kwargs) -> None:
         """Create a new user on the Nextcloud server.
 
         :param user_id: id of the user to create.

--- a/nc_py_api/users_groups.py
+++ b/nc_py_api/users_groups.py
@@ -1,7 +1,6 @@
 """Nextcloud API for working with user groups."""
 
 import dataclasses
-import typing
 
 from ._misc import kwargs_to_params
 from ._session import NcSessionBasic
@@ -59,23 +58,21 @@ class _UsersGroupsAPI:
     def __init__(self, session: NcSessionBasic):
         self._session = session
 
-    def get_list(
-        self, mask: typing.Optional[str] = None, limit: typing.Optional[int] = None, offset: typing.Optional[int] = None
-    ) -> list[str]:
+    def get_list(self, mask: str | None = None, limit: int | None = None, offset: int | None = None) -> list[str]:
         """Returns a list of user groups IDs."""
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
         response_data = self._session.ocs("GET", self._ep_base, params=data)
         return response_data["groups"] if response_data else []
 
     def get_details(
-        self, mask: typing.Optional[str] = None, limit: typing.Optional[int] = None, offset: typing.Optional[int] = None
+        self, mask: str | None = None, limit: int | None = None, offset: int | None = None
     ) -> list[GroupDetails]:
         """Returns a list of user groups with detailed information."""
         data = kwargs_to_params(["search", "limit", "offset"], search=mask, limit=limit, offset=offset)
         response_data = self._session.ocs("GET", f"{self._ep_base}/details", params=data)
         return [GroupDetails(i) for i in response_data["groups"]] if response_data else []
 
-    def create(self, group_id: str, display_name: typing.Optional[str] = None) -> None:
+    def create(self, group_id: str, display_name: str | None = None) -> None:
         """Creates the users group."""
         params = {"groupid": group_id}
         if display_name is not None:

--- a/nc_py_api/weather_status.py
+++ b/nc_py_api/weather_status.py
@@ -2,7 +2,6 @@
 
 import dataclasses
 import enum
-import typing
 
 from ._misc import check_capabilities, require_capabilities
 from ._session import NcSessionBasic
@@ -61,9 +60,9 @@ class _WeatherStatusAPI:
 
     def set_location(
         self,
-        latitude: typing.Optional[float] = None,
-        longitude: typing.Optional[float] = None,
-        address: typing.Optional[str] = None,
+        latitude: float | None = None,
+        longitude: float | None = None,
+        address: str | None = None,
     ) -> bool:
         """Sets the user's location on the Nextcloud server.
 
@@ -72,7 +71,7 @@ class _WeatherStatusAPI:
         :param address: city, index(*optional*) and country, e.g. "Paris, 75007, France"
         """
         require_capabilities("weather_status.enabled", self._session.capabilities)
-        params: dict[str, typing.Union[str, float]] = {}
+        params: dict[str, str | float] = {}
         if latitude is not None and longitude is not None:
             params.update({"lat": latitude, "lon": longitude})
         elif address:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = "BSD-3-Clause"
 authors = [
     { name = "Alexander Piskun", email = "bigcat88@icloud.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
@@ -28,7 +28,6 @@ classifiers = [
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -105,12 +104,12 @@ exclude = [
 
 [tool.black]
 line-length = 120
-target-versions = ["py39"]
+target-versions = ["py310"]
 preview = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 select = ["A", "B", "C", "D", "E", "F", "G", "I", "S", "SIM", "PIE", "Q", "RET", "RUF", "UP" , "W"]
 extend-ignore = ["D107", "D105", "D203", "D213", "D401", "I001", "RUF100"]
 
@@ -131,7 +130,7 @@ max-complexity = 16
 profile = "black"
 
 [tool.pylint]
-master.py-version = "3.9"
+master.py-version = "3.10"
 master.extension-pkg-allow-list = ["pydantic"]
 design.max-attributes = 8
 design.max-locals = 16


### PR DESCRIPTION
Before adding support for **Async**, we remove Python 3.9 support in order to reduce the amount of work later, since support for asynchrony will add a lot of duplicate code.

_I do this with pain in my heart_