### PR TITLE
added public `ocs` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.1 - 2022-12-2x]
+
+### Added
+
+- The `ocs` method is now public, making it easy to use Nextcloud OCS that has not yet been described.
+
 ## [0.7.0 - 2022-12-17]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- The `ocs` method is now public, making it easy to use Nextcloud OCS that has not yet been described.
+- The `ocs` method is now public, making it easy to use Nextcloud OCS that has not yet been described. #187
 
 ## [0.7.0 - 2022-12-17]
 

--- a/nc_py_api/_version.py
+++ b/nc_py_api/_version.py
@@ -1,3 +1,3 @@
 """Version of nc_py_api."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1.dev0"

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -1,5 +1,6 @@
 """Nextcloud class providing access to all API endpoints."""
 
+import typing
 from abc import ABC
 
 from fastapi import Request as FastAPIRequest
@@ -112,6 +113,19 @@ class _NextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         """Returns Theme information."""
         return get_parsed_theme(self.capabilities["theming"]) if "theming" in self.capabilities else None
 
+    def ocs(
+        self,
+        method: str,
+        path: str,
+        *,
+        content: bytes | str | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
+        json: dict | list | None = None,
+        params: dict | None = None,
+        **kwargs,
+    ):
+        """Performs OCS call and returns OCS response payload data."""
+        return self._session.ocs(method, path, content=content, json=json, params=params, **kwargs)
+
 
 class _AsyncNextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
     apps: _AsyncAppsAPI
@@ -184,6 +198,19 @@ class _AsyncNextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
     async def theme(self) -> ThemingInfo | None:
         """Returns Theme information."""
         return get_parsed_theme((await self.capabilities)["theming"]) if "theming" in await self.capabilities else None
+
+    async def ocs(
+        self,
+        method: str,
+        path: str,
+        *,
+        content: bytes | str | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
+        json: dict | list | None = None,
+        params: dict | None = None,
+        **kwargs,
+    ):
+        """Performs OCS call and returns OCS response payload data."""
+        return await self._session.ocs(method, path, content=content, json=json, params=params, **kwargs)
 
 
 class Nextcloud(_NextcloudBasic):

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -167,3 +167,16 @@ async def test_ocs_timeout_async(anc_any):
     if e.value.status_code in (500, 996):
         pytest.skip("Some network problem on the host")
     assert e.value.status_code == 408
+
+
+def test_public_ocs(nc_any):
+    r = nc_any.ocs("GET", "/ocs/v1.php/cloud/capabilities")
+    assert r == nc_any.ocs("GET", "ocs/v1.php/cloud/capabilities")
+    assert r == nc_any._session.ocs("GET", "ocs/v1.php/cloud/capabilities")  # noqa
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_public_ocs_async(anc_any):
+    r = await anc_any.ocs("GET", "/ocs/v1.php/cloud/capabilities")
+    assert r == await anc_any.ocs("GET", "ocs/v1.php/cloud/capabilities")
+    assert r == await anc_any._session.ocs("GET", "ocs/v1.php/cloud/capabilities")  # noqa


### PR DESCRIPTION
Many OCS have not yet been described, but can now be used quite easily using the "osc" method.

_I couldn't add it before because... I didn’t know whether the OCS prototype would change or not, now I already know that it won’t._