### PR TITLE
added "perform_login" method

### DIFF
--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -113,6 +113,14 @@ class _NextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         """Returns Theme information."""
         return get_parsed_theme(self.capabilities["theming"]) if "theming" in self.capabilities else None
 
+    def perform_login(self) -> bool:
+        """Performs login into Nextcloud if not already logged in; manual invocation of this method is unnecessary."""
+        try:
+            self.update_server_info()
+        except Exception:  # noqa pylint: disable=broad-exception-caught
+            return False
+        return True
+
     def ocs(
         self,
         method: str,
@@ -198,6 +206,14 @@ class _AsyncNextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
     async def theme(self) -> ThemingInfo | None:
         """Returns Theme information."""
         return get_parsed_theme((await self.capabilities)["theming"]) if "theming" in await self.capabilities else None
+
+    async def perform_login(self) -> bool:
+        """Performs login into Nextcloud if not already logged in; manual invocation of this method is unnecessary."""
+        try:
+            await self.update_server_info()
+        except Exception:  # noqa pylint: disable=broad-exception-caught
+            return False
+        return True
 
     async def ocs(
         self,

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -180,3 +180,18 @@ async def test_public_ocs_async(anc_any):
     r = await anc_any.ocs("GET", "/ocs/v1.php/cloud/capabilities")
     assert r == await anc_any.ocs("GET", "ocs/v1.php/cloud/capabilities")
     assert r == await anc_any._session.ocs("GET", "ocs/v1.php/cloud/capabilities")  # noqa
+
+
+def test_perform_login(nc_any):
+    new_nc = Nextcloud() if isinstance(nc_any, Nextcloud) else NextcloudApp()
+    assert not new_nc._session._capabilities
+    new_nc.perform_login()
+    assert new_nc._session._capabilities
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_perform_login_async(anc_any):
+    new_nc = AsyncNextcloud() if isinstance(anc_any, Nextcloud) else AsyncNextcloudApp()
+    assert not new_nc._session._capabilities
+    await new_nc.perform_login()
+    assert new_nc._session._capabilities


### PR DESCRIPTION
Ref: [#193](https://github.com/cloud-py-api/nc_py_api/issues/193#issuecomment-1870923612) point 1.

Added a separate login function named "perform_login" that can be called manually for easy check whether the login success or not

