### PR TITLE
skip OCS parsing when status == NO CONTENT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - API for registering Speech to Text provider(*avalaible from Nextcloud 29*). #196
 
+### Fixed
+
+- OCS: Correctly handling of `HTTP 204 No Content` status. #197
+
 ## [0.7.2 - 2023-12-28]
 
 ### Fixed

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -199,7 +199,7 @@ class NcSessionBasic(NcSessionBase, ABC):
 
         check_error(response, info)
         if response.status_code == 204:  # NO_CONTENT
-            return ""
+            return []
         response_data = loads(response.text)
         ocs_meta = response_data["ocs"]["meta"]
         if ocs_meta["status"] != "ok":
@@ -300,6 +300,8 @@ class AsyncNcSessionBasic(NcSessionBase, ABC):
             raise NextcloudException(408, info=info) from None
 
         check_error(response, info)
+        if response.status_code == 204:  # NO_CONTENT
+            return []
         response_data = loads(response.text)
         ocs_meta = response_data["ocs"]["meta"]
         if ocs_meta["status"] != "ok":

--- a/nc_py_api/ex_app/defs.py
+++ b/nc_py_api/ex_app/defs.py
@@ -44,4 +44,6 @@ class ApiScope(enum.IntEnum):
     ACTIVITIES = 110
     """Activity App endpoints."""
     NOTES = 120
-    """Notes App endpoints"""
+    """Notes App endpoints."""
+    ALL = 9999
+    """All endpoints allowed."""

--- a/scripts/ci_register.sh
+++ b/scripts/ci_register.sh
@@ -5,5 +5,5 @@
 
 php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
 php occ app_api:app:register "$1" manual_install --json-info \
-  "{\"appid\":\"$1\",\"name\":\"$1\",\"daemon_config_name\":\"manual_install\",\"version\":\"$2\",\"secret\":\"$3\",\"host\":\"$4\",\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\", \"TALK_BOT\", \"ACTIVITIES\", \"NOTES\", \"AI_PROVIDERS\"]},\"port\":$5,\"protocol\":\"http\",\"system_app\":1}" \
+  "{\"appid\":\"$1\",\"name\":\"$1\",\"daemon_config_name\":\"manual_install\",\"version\":\"$2\",\"secret\":\"$3\",\"host\":\"$4\",\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"port\":$5,\"protocol\":\"http\",\"system_app\":1}" \
   --force-scopes --wait-finish

--- a/scripts/dev_register.sh
+++ b/scripts/dev_register.sh
@@ -13,7 +13,7 @@ NEXTCLOUD_URL="http://$2" APP_PORT=9009 APP_ID="nc_py_api" APP_SECRET="12345" AP
 echo $! > /tmp/_install.pid
 python3 tests/_install_wait.py "http://localhost:9009/heartbeat" "\"status\":\"ok\"" 15 0.5
 docker exec "$1" sudo -u www-data php occ app_api:app:register nc_py_api manual_install --json-info \
-  "{\"appid\":\"nc_py_api\",\"name\":\"nc_py_api\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\", \"TALK_BOT\", \"ACTIVITIES\", \"NOTES\", \"AI_PROVIDERS\"]},\"port\":9009,\"protocol\":\"http\",\"system_app\":1}" \
+  "{\"appid\":\"nc_py_api\",\"name\":\"nc_py_api\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"port\":9009,\"protocol\":\"http\",\"system_app\":1}" \
   --force-scopes --wait-finish
 cat /tmp/_install.pid
 kill -15 "$(cat /tmp/_install.pid)"

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -182,6 +182,17 @@ async def test_public_ocs_async(anc_any):
     assert r == await anc_any._session.ocs("GET", "ocs/v1.php/cloud/capabilities")  # noqa
 
 
+def test_all_scope(nc_any):
+    r = nc_any.ocs("GET", "/ocs/v2.php/core/whatsnew")
+    assert isinstance(r, list)
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_all_scope_async(anc_any):
+    r = await anc_any.ocs("GET", "/ocs/v2.php/core/whatsnew")
+    assert isinstance(r, list)
+
+
 def test_perform_login(nc_any):
     new_nc = Nextcloud() if isinstance(nc_any, Nextcloud) else NextcloudApp()
     assert not new_nc._session._capabilities

--- a/tests/actual_tests/nc_app_test.py
+++ b/tests/actual_tests/nc_app_test.py
@@ -21,7 +21,10 @@ async def test_get_users_list_async(anc_app):
 
 def test_scope_allowed(nc_app):
     for i in ApiScope:
-        assert nc_app.scope_allowed(i)
+        if i == ApiScope.ALL.value:
+            assert nc_app.scope_allowed(i)
+        else:
+            assert not nc_app.scope_allowed(i)
     assert not nc_app.scope_allowed(0)  # noqa
     assert not nc_app.scope_allowed(999999999)  # noqa
 
@@ -29,7 +32,10 @@ def test_scope_allowed(nc_app):
 @pytest.mark.asyncio(scope="session")
 async def test_scope_allowed_async(anc_app):
     for i in ApiScope:
-        assert await anc_app.scope_allowed(i)
+        if i == ApiScope.ALL.value:
+            assert await anc_app.scope_allowed(i)
+        else:
+            assert not await anc_app.scope_allowed(i)
     assert not await anc_app.scope_allowed(0)  # noqa
     assert not await anc_app.scope_allowed(999999999)  # noqa
 
@@ -50,12 +56,12 @@ async def test_app_cfg_async(anc_app):
 
 
 def test_scope_allow_app_ecosystem_disabled(nc_client, nc_app):
-    assert nc_app.scope_allowed(ApiScope.FILES)
+    assert nc_app.scope_allowed(ApiScope.ALL)
     nc_client.apps.disable("app_api")
     try:
-        assert nc_app.scope_allowed(ApiScope.FILES)
+        assert nc_app.scope_allowed(ApiScope.ALL)
         nc_app.update_server_info()
-        assert not nc_app.scope_allowed(ApiScope.FILES)
+        assert not nc_app.scope_allowed(ApiScope.ALL)
     finally:
         nc_client.apps.enable("app_api")
         nc_app.update_server_info()
@@ -63,12 +69,12 @@ def test_scope_allow_app_ecosystem_disabled(nc_client, nc_app):
 
 @pytest.mark.asyncio(scope="session")
 async def test_scope_allow_app_ecosystem_disabled_async(anc_client, anc_app):
-    assert await anc_app.scope_allowed(ApiScope.FILES)
+    assert await anc_app.scope_allowed(ApiScope.ALL)
     await anc_client.apps.disable("app_api")
     try:
-        assert await anc_app.scope_allowed(ApiScope.FILES)
+        assert await anc_app.scope_allowed(ApiScope.ALL)
         await anc_app.update_server_info()
-        assert not await anc_app.scope_allowed(ApiScope.FILES)
+        assert not await anc_app.scope_allowed(ApiScope.ALL)
     finally:
         await anc_client.apps.enable("app_api")
         await anc_app.update_server_info()


### PR DESCRIPTION
This code were not working:

```python3
nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
```

this PR fixes it, for OCS that return `Http::STATUS_NO_CONTENT` we return empty list.

In addition added `ALL` API scope, ref: cloud-py-api/app_api/pull/190

Previous commit: https://github.com/cloud-py-api/nc_py_api/commit/8fd175adeb038f1f5f16dde076cc8a2ee2eb052c was added fast to just implement `ALL` API scope tests in AppAPI repo.