### PR TITLE
CI-tests: specify default value for dict.pop operation

### DIFF
--- a/tests/_talk_bot.py
+++ b/tests/_talk_bot.py
@@ -57,7 +57,7 @@ def talk_bot_coverage(
 # in real program this is not needed, as bot enabling handler is called in the bots process itself and will reset it.
 @APP.delete("/reset_bot_secret")
 def reset_bot_secret():
-    os.environ.pop(talk_bot.__get_bot_secret("/talk_bot_coverage"))
+    os.environ.pop(talk_bot.__get_bot_secret("/talk_bot_coverage"), None)
     return Response()
 
 

--- a/tests/_talk_bot_async.py
+++ b/tests/_talk_bot_async.py
@@ -45,7 +45,7 @@ async def talk_bot_coverage(
 # in real program this is not needed, as bot enabling handler is called in the bots process itself and will reset it.
 @APP.delete("/reset_bot_secret")
 async def reset_bot_secret():
-    os.environ.pop(talk_bot.__get_bot_secret("/talk_bot_coverage"))
+    os.environ.pop(talk_bot.__get_bot_secret("/talk_bot_coverage"), None)
     return Response()
 
 


### PR DESCRIPTION
Nothing special, just clean up.

Need to clear this from the result of Tests on GitHub:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 426, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/uvicorn/middleware/message_logger.py", line 84, in __call__
    raise exc from None
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/uvicorn/middleware/message_logger.py", line 80, in __call__
    await self.app(scope, inner_receive, inner_send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/routing.py", line 762, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/routing.py", line 782, in app
    await route.handle(scope, receive, send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/routing.py", line 297, in handle
    await self.app(scope, receive, send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/routing.py", line 77, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/starlette/routing.py", line 72, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/fastapi/routing.py", line 299, in app
    raise e
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/fastapi/routing.py", line 294, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/nc_py_api/nc_py_api/nc_py_api/tests/_talk_bot_async.py", line 48, in reset_bot_secret
    os.environ.pop(talk_bot.__get_bot_secret("/talk_bot_coverage"))
  File "<frozen _collections_abc>", line 912, in pop
  File "<frozen os>", line 679, in __getitem__
KeyError: '475d361d4f3c5edf778c3960accba70f699af6eb'
```