### PR TITLE
AppAPI 2.0

### DIFF
--- a/.run/Skeleton (27).run.xml
+++ b/.run/Skeleton (27).run.xml
@@ -1,16 +1,17 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Skeleton (27)" type="PythonConfigurationType" factoryName="Python">
     <module name="nc_py_api" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
+      <env name="APP_HOST" value="127.0.0.1" />
       <env name="APP_ID" value="skeleton" />
-      <env name="APP_PORT" value="9030" />
+      <env name="APP_PORT" value="23745" />
       <env name="APP_SECRET" value="12345" />
       <env name="APP_VERSION" value="1.0.0" />
       <env name="NEXTCLOUD_URL" value="http://stable27.local/index.php" />
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="APP_HOST" value="0.0.0.0" />
     </envs>
     <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples/as_app/skeleton/lib" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.8.1 - 2024-01-xx]
+## [0.9.0 - 2024-01-25]
 
 ### Added
 
@@ -12,7 +12,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **large amount of incompatible changes** for `AppAPI 2.0`, see PR for description. #212
 - class `Share`.raw_data marked as deprecated and changed to `_raw_data`. #206
+- `ex_app.talk_bot_app`/`ex_app.atalk_bot_app` renamed to `ex_app.talk_bot_msg`/`ex_app.atalk_bot_msg`.
 
 ## [0.8.0 - 2024-01-12]
 

--- a/docs/NextcloudApp.rst
+++ b/docs/NextcloudApp.rst
@@ -66,7 +66,7 @@ First register ``manual_install`` daemon:
 
 .. code-block:: shell
 
-    php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
+    php occ app_api:daemon:register manual_install "Manual Install" manual-install http host.docker.internal 0
 
 Then, launch your application. Since this is a manual deployment, it's your responsibility to set minimum of the environment variables.
 Here they are:
@@ -86,7 +86,7 @@ After launching your application, execute the following command in the Nextcloud
 .. code-block:: shell
 
     php occ app_api:app:register YOUR_APP_ID manual_install --json-info \
-        "{\"appid\":\"YOUR_APP_ID\",\"name\":\"YOUR_APP_DISPLAY_NAME\",\"daemon_config_name\":\"manual_install\",\"version\":\"YOU_APP_VERSION\",\"secret\":\"YOUR_APP_SECRET\",\"host\":\"host.docker.internal\",\"scopes\":{\"required\":[2, 10, 11],\"optional\":[30, 31, 32, 33]},\"port\":SELECTED_PORT,\"protocol\":\"http\",\"system_app\":0}" \
+        "{\"appid\":\"YOUR_APP_ID\",\"name\":\"YOUR_APP_DISPLAY_NAME\",\"daemon_config_name\":\"manual_install\",\"version\":\"YOU_APP_VERSION\",\"secret\":\"YOUR_APP_SECRET\",\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"port\":SELECTED_PORT,\"system_app\":0}" \
         --force-scopes --wait-finish
 
 You can see how **nc_py_api** registers in ``scripts/dev_register.sh``.
@@ -226,8 +226,7 @@ and since this is not directly related to working with NextCloud, we will skip t
 Using AppAPIAuthMiddleware
 --------------------------
 
-If your application does not implement `Talk Bot` functionality and you most often do not need
-the ``NextcloudApp`` class returned after standard authentication with `Depends`:
+If in your application in most cases you don't really need the ``NextcloudApp`` class returned after standard authentication using `Depends`:
 
 .. code-block:: python
 

--- a/docs/NextcloudTalkBot.rst
+++ b/docs/NextcloudTalkBot.rst
@@ -40,16 +40,18 @@ Afterward, using FastAPI, you can define endpoints that will be invoked by Talk:
 
     @APP.post("/currency_talk_bot")
     async def currency_talk_bot(
-        message: Annotated[talk_bot.TalkBotMessage, Depends(talk_bot_app)],
+        _nc: Annotated[NextcloudApp, Depends(nc_app)],
+        message: Annotated[talk_bot.TalkBotMessage, Depends(atalk_bot_msg)],
         background_tasks: BackgroundTasks,
     ):
         return Response()
 
 .. note::
-    You must include to each endpoint your bot provides the **Depends(talk_bot_app)**.
-    **message: Annotated[talk_bot.TalkBotMessage, Depends(talk_bot_app)]**
+    You must include to each endpoint your bot provides the **Depends(nc_app)**.
 
-Depending on **talk_bot_app** serves as an automatic authentication handler for messages from the cloud, which returns the received message from Nextcloud upon successful authentication.
+    Depending on **nc_app** serves as an automatic authentication handler for messages from the cloud.
+
+**message: Annotated[talk_bot.TalkBotMessage, Depends(talk_bot_app)]** - returns the received message from Nextcloud upon successful authentication.
 
 Additionally, if your bot can provide quick and fixed execution times, you may not need to create background tasks.
 However, in most cases, it's recommended to segregate functionality and perform operations in the background, while promptly returning an empty response to Nextcloud.

--- a/examples/as_app/skeleton/Makefile
+++ b/examples/as_app/skeleton/Makefile
@@ -69,19 +69,19 @@ run:
 register27:
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister skeleton --silent --force || true
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register skeleton manual_install --json-info \
-  "{\"appid\":\"skeleton\",\"name\":\"App Skeleton\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9030,\"scopes\":{\"required\":[],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"skeleton\",\"name\":\"App Skeleton\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9030,\"scopes\":{\"required\":[],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish
 
 .PHONY: register28
 register28:
 	docker exec master-stable28-1 sudo -u www-data php occ app_api:app:unregister skeleton --silent --force || true
 	docker exec master-stable28-1 sudo -u www-data php occ app_api:app:register skeleton manual_install --json-info \
-  "{\"appid\":\"skeleton\",\"name\":\"App Skeleton\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9030,\"scopes\":{\"required\":[],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"skeleton\",\"name\":\"App Skeleton\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9030,\"scopes\":{\"required\":[],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish
 
 .PHONY: register
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister skeleton --silent --force || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register skeleton manual_install --json-info \
-  "{\"appid\":\"skeleton\",\"name\":\"App Skeleton\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9030,\"scopes\":{\"required\":[],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"skeleton\",\"name\":\"App Skeleton\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9030,\"scopes\":{\"required\":[],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish

--- a/examples/as_app/skeleton/appinfo/info.xml
+++ b/examples/as_app/skeleton/appinfo/info.xml
@@ -30,7 +30,6 @@
 			<optional>
 			</optional>
 		</scopes>
-		<protocol>http</protocol>
 		<system>false</system>
 	</external-app>
 </info>

--- a/examples/as_app/talk_bot/Makefile
+++ b/examples/as_app/talk_bot/Makefile
@@ -54,12 +54,12 @@ run27:
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister talk_bot --silent --force || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register talk_bot manual_install --json-info \
-  "{\"appid\":\"talk_bot\",\"name\":\"TalkBot\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9032,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"talk_bot\",\"name\":\"TalkBot\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9032,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish
 
 .PHONY: register27
 register27:
-	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister talk_bot --silent --force || true
+	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister talk_bot --force || true
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register talk_bot manual_install --json-info \
-  "{\"appid\":\"talk_bot\",\"name\":\"TalkBot\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9032,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"talk_bot\",\"name\":\"TalkBot\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9032,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish

--- a/examples/as_app/talk_bot/appinfo/info.xml
+++ b/examples/as_app/talk_bot/appinfo/info.xml
@@ -32,7 +32,6 @@
 			<optional>
 			</optional>
 		</scopes>
-		<protocol>http</protocol>
 		<system>false</system>
 	</external-app>
 </info>

--- a/examples/as_app/talk_bot/lib/main.py
+++ b/examples/as_app/talk_bot/lib/main.py
@@ -8,7 +8,7 @@ import httpx
 from fastapi import BackgroundTasks, Depends, FastAPI, Response
 
 from nc_py_api import NextcloudApp, talk_bot
-from nc_py_api.ex_app import run_app, set_handlers, talk_bot_app
+from nc_py_api.ex_app import atalk_bot_msg, nc_app, run_app, set_handlers
 
 
 # The same stuff as for usual External Applications
@@ -66,7 +66,8 @@ def currency_talk_bot_process_request(message: talk_bot.TalkBotMessage):
 
 @APP.post("/currency_talk_bot")
 async def currency_talk_bot(
-    message: Annotated[talk_bot.TalkBotMessage, Depends(talk_bot_app)],
+    _nc: Annotated[NextcloudApp, Depends(nc_app)],
+    message: Annotated[talk_bot.TalkBotMessage, Depends(atalk_bot_msg)],
     background_tasks: BackgroundTasks,
 ):
     # As during converting, we do not process converting locally, we perform this in background, in the background task.

--- a/examples/as_app/talk_bot_ai/Makefile
+++ b/examples/as_app/talk_bot_ai/Makefile
@@ -54,12 +54,12 @@ run27:
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister talk_bot_ai --silent --force || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register talk_bot_ai manual_install --json-info \
-  "{\"appid\":\"talk_bot_ai\",\"name\":\"TalkBotAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9034,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"talk_bot_ai\",\"name\":\"TalkBotAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9034,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish
 
 .PHONY: register27
 register27:
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister talk_bot_ai --silent --force || true
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register talk_bot_ai manual_install --json-info \
-  "{\"appid\":\"talk_bot_ai\",\"name\":\"TalkBotAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9034,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"talk_bot_ai\",\"name\":\"TalkBotAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9034,\"scopes\":{\"required\":[\"TALK\", \"TALK_BOT\"],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish

--- a/examples/as_app/talk_bot_ai/appinfo/info.xml
+++ b/examples/as_app/talk_bot_ai/appinfo/info.xml
@@ -32,7 +32,6 @@
 			<optional>
 			</optional>
 		</scopes>
-		<protocol>http</protocol>
 		<system>false</system>
 	</external-app>
 </info>

--- a/examples/as_app/talk_bot_ai/lib/main.py
+++ b/examples/as_app/talk_bot_ai/lib/main.py
@@ -9,7 +9,13 @@ from fastapi import BackgroundTasks, Depends, FastAPI
 from transformers import pipeline
 
 from nc_py_api import NextcloudApp, talk_bot
-from nc_py_api.ex_app import get_model_path, run_app, set_handlers, talk_bot_app
+from nc_py_api.ex_app import (
+    atalk_bot_msg,
+    get_model_path,
+    nc_app,
+    run_app,
+    set_handlers,
+)
 
 
 @asynccontextmanager
@@ -34,7 +40,8 @@ def ai_talk_bot_process_request(message: talk_bot.TalkBotMessage):
 
 @APP.post("/ai_talk_bot")
 async def ai_talk_bot(
-    message: Annotated[talk_bot.TalkBotMessage, Depends(talk_bot_app)],
+    _nc: Annotated[NextcloudApp, Depends(nc_app)],
+    message: Annotated[talk_bot.TalkBotMessage, Depends(atalk_bot_msg)],
     background_tasks: BackgroundTasks,
 ):
     if message.object_name == "message":

--- a/examples/as_app/to_gif/Makefile
+++ b/examples/as_app/to_gif/Makefile
@@ -69,19 +69,19 @@ run:
 register27:
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister to_gif --silent --force || true
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register to_gif manual_install --json-info \
-  "{\"appid\":\"to_gif\",\"name\":\"to_gif\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9031,\"scopes\":{\"required\":[\"FILES\", \"NOTIFICATIONS\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"to_gif\",\"name\":\"to_gif\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":{\"required\":[\"FILES\", \"NOTIFICATIONS\"],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish
 
 .PHONY: register28
 register28:
 	docker exec master-stable28-1 sudo -u www-data php occ app_api:app:unregister to_gif --silent --force || true
 	docker exec master-stable28-1 sudo -u www-data php occ app_api:app:register to_gif manual_install --json-info \
-  "{\"appid\":\"to_gif\",\"name\":\"to_gif\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9031,\"scopes\":{\"required\":[\"FILES\", \"NOTIFICATIONS\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"to_gif\",\"name\":\"to_gif\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":{\"required\":[\"FILES\", \"NOTIFICATIONS\"],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish
 
 .PHONY: register
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister to_gif --silent --force || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register to_gif manual_install --json-info \
-  "{\"appid\":\"to_gif\",\"name\":\"to_gif\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9031,\"scopes\":{\"required\":[\"FILES\", \"NOTIFICATIONS\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"to_gif\",\"name\":\"to_gif\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":{\"required\":[\"FILES\", \"NOTIFICATIONS\"],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish

--- a/examples/as_app/to_gif/appinfo/info.xml
+++ b/examples/as_app/to_gif/appinfo/info.xml
@@ -32,7 +32,6 @@
 			<optional>
 			</optional>
 		</scopes>
-		<protocol>http</protocol>
 		<system>false</system>
 	</external-app>
 </info>

--- a/examples/as_app/ui_example/Makefile
+++ b/examples/as_app/ui_example/Makefile
@@ -69,19 +69,19 @@ run:
 register27:
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister ui_example --silent --force || true
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register ui_example manual_install --json-info \
-  "{\"appid\":\"ui_example\",\"name\":\"UI Example\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9035,\"scopes\":{\"required\":[],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"ui_example\",\"name\":\"UI Example\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9035,\"scopes\":{\"required\":[],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish
 
 .PHONY: register28
 register28:
 	docker exec master-stable28-1 sudo -u www-data php occ app_api:app:unregister ui_example --silent --force || true
 	docker exec master-stable28-1 sudo -u www-data php occ app_api:app:register ui_example manual_install --json-info \
-  "{\"appid\":\"ui_example\",\"name\":\"UI Example\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9035,\"scopes\":{\"required\":[],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"ui_example\",\"name\":\"UI Example\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9035,\"scopes\":{\"required\":[],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish
 
 .PHONY: register
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister ui_example --silent --force || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register ui_example manual_install --json-info \
-  "{\"appid\":\"ui_example\",\"name\":\"UI Example\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9035,\"scopes\":{\"required\":[],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"ui_example\",\"name\":\"UI Example\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9035,\"scopes\":{\"required\":[],\"optional\":[]},\"system_app\":0}" \
   --force-scopes --wait-finish

--- a/examples/as_app/ui_example/appinfo/info.xml
+++ b/examples/as_app/ui_example/appinfo/info.xml
@@ -30,7 +30,6 @@
 			<optional>
 			</optional>
 		</scopes>
-		<protocol>http</protocol>
 		<system>false</system>
 	</external-app>
 </info>

--- a/nc_py_api/_version.py
+++ b/nc_py_api/_version.py
@@ -1,3 +1,3 @@
 """Version of nc_py_api."""
 
-__version__ = "0.8.1.dev0"
+__version__ = "0.9.0.dev0"

--- a/nc_py_api/ex_app/__init__.py
+++ b/nc_py_api/ex_app/__init__.py
@@ -4,10 +4,10 @@ from .defs import ApiScope, LogLvl
 from .integration_fastapi import (
     AppAPIAuthMiddleware,
     anc_app,
-    atalk_bot_app,
+    atalk_bot_msg,
     nc_app,
     set_handlers,
-    talk_bot_app,
+    talk_bot_msg,
 )
 from .misc import get_model_path, persistent_storage, verify_version
 from .ui.files_actions import UiActionFileInfo

--- a/nc_py_api/files/__init__.py
+++ b/nc_py_api/files/__init__.py
@@ -305,7 +305,7 @@ class Share:
     def __getattr__(self, name):
         if name == "raw_data":
             warnings.warn(
-                f"{name} is deprecated and will be removed in 0.9.0 version.", DeprecationWarning, stacklevel=2
+                f"{name} is deprecated and will be removed in 0.10.0 version.", DeprecationWarning, stacklevel=2
             )
             return self._raw_data
         return getattr(self, name)

--- a/nc_py_api/talk_bot.py
+++ b/nc_py_api/talk_bot.py
@@ -94,7 +94,7 @@ class TalkBot:
         :param display_name: The display name of the bot that is shown as author when it posts a message or reaction.
         :param description: Description of the bot helping moderators to decide if they want to enable this bot.
         """
-        self.callback_url = callback_url
+        self.callback_url = callback_url.lstrip("/")
         self.display_name = display_name
         self.description = description
 

--- a/scripts/ci_register.sh
+++ b/scripts/ci_register.sh
@@ -3,7 +3,7 @@
 # Parameters:
 # APP_ID, VERSION, SECRET, HOST, PORT
 
-php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
+php occ app_api:daemon:register manual_install "Manual Install" manual-install http "$4" 0
 php occ app_api:app:register "$1" manual_install --json-info \
-  "{\"appid\":\"$1\",\"name\":\"$1\",\"daemon_config_name\":\"manual_install\",\"version\":\"$2\",\"secret\":\"$3\",\"host\":\"$4\",\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"port\":$5,\"protocol\":\"http\",\"system_app\":1}" \
+  "{\"appid\":\"$1\",\"name\":\"$1\",\"daemon_config_name\":\"manual_install\",\"version\":\"$2\",\"secret\":\"$3\",\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"port\":$5,\"system_app\":1}" \
   --force-scopes --wait-finish

--- a/scripts/dev_register.sh
+++ b/scripts/dev_register.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
 
-echo "removing 'manual_install' deploy daemon for $1 container"
-docker exec "$1" sudo -u www-data php occ app_api:daemon:unregister manual_install || true
 echo "creating 'manual_install' deploy daemon for $1 container"
 docker exec "$1" sudo -u www-data php occ app_api:daemon:register \
-  manual_install "Manual Install" manual-install 0 0 0
+  manual_install "Manual Install" manual-install http host.docker.internal 0
 echo "unregistering nc_py_api as an app for $1 container"
 docker exec "$1" sudo -u www-data php occ app_api:app:unregister nc_py_api --silent --force || true
 echo "registering nc_py_api as an app for $1 container"
-NEXTCLOUD_URL="http://$2" APP_PORT=9009 APP_ID="nc_py_api" APP_SECRET="12345" APP_VERSION="1.0.0" \
-  python3 tests/_install.py > /dev/null 2>&1 &
-echo $! > /tmp/_install.pid
-python3 tests/_install_wait.py "http://localhost:9009/heartbeat" "\"status\":\"ok\"" 15 0.5
 docker exec "$1" sudo -u www-data php occ app_api:app:register nc_py_api manual_install --json-info \
-  "{\"appid\":\"nc_py_api\",\"name\":\"nc_py_api\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"port\":9009,\"protocol\":\"http\",\"system_app\":1}" \
+  "{\"appid\":\"nc_py_api\",\"name\":\"nc_py_api\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"port\":9009,\"system_app\":1}" \
   --force-scopes --wait-finish
-cat /tmp/_install.pid
-kill -15 "$(cat /tmp/_install.pid)"
 echo "nc_py_api for $1 is ready to use"

--- a/tests/_talk_bot_async.py
+++ b/tests/_talk_bot_async.py
@@ -5,8 +5,8 @@ import gfixture_set_env  # noqa
 import pytest
 from fastapi import BackgroundTasks, Depends, FastAPI, Request, Response
 
-from nc_py_api import talk_bot
-from nc_py_api.ex_app import atalk_bot_app, run_app
+from nc_py_api import AsyncNextcloudApp, talk_bot
+from nc_py_api.ex_app import anc_app, atalk_bot_msg, run_app
 
 APP = FastAPI()
 COVERAGE_BOT = talk_bot.AsyncTalkBot("/talk_bot_coverage", "Coverage bot", "Desc")
@@ -35,7 +35,8 @@ async def coverage_talk_bot_process_request(message: talk_bot.TalkBotMessage, re
 @APP.post("/talk_bot_coverage")
 async def talk_bot_coverage(
     request: Request,
-    message: Annotated[talk_bot.TalkBotMessage, Depends(atalk_bot_app)],
+    _nc: Annotated[AsyncNextcloudApp, Depends(anc_app)],
+    message: Annotated[talk_bot.TalkBotMessage, Depends(atalk_bot_msg)],
     background_tasks: BackgroundTasks,
 ):
     background_tasks.add_task(coverage_talk_bot_process_request, message, request)


### PR DESCRIPTION
See: https://github.com/cloud-py-api/app_api/issues/213

1. _All Talk Bots should be updated to use AppAPI auth for input endpoints._
2. Updated Documentation reflecting last changes.
3. CI will fail, until merge in AppAPI will finished.