### PR TITLE
CI: coverage upload fix

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,7 +1,3 @@
-codecov:
-  notify:
-    after_n_builds: 11
-
 comment:
   require_changes: true
   layout: "diff, files"

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -916,9 +916,6 @@ jobs:
           pattern: coverage_*
           merge-multiple: true
 
-      - name: debug
-        run: ls -la && ls -la coverage
-
       - name: Upload report to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -183,7 +183,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_maria_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
-          file: nc_py_api/coverage.xml
+          path: nc_py_api/coverage.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -342,7 +342,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_pgsql_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
-          file: nc_py_api/coverage.xml
+          path: nc_py_api/coverage.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -458,7 +458,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_oci_stable27_3.11_8.1.xml
-          file: nc_py_api/coverage.xml
+          path: nc_py_api/coverage.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -632,7 +632,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_maria_${{ matrix.nextcloud }}.xml
-          file: nc_py_api/coverage.xml
+          path: nc_py_api/coverage.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -810,7 +810,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_pgsql_${{ matrix.nextcloud }}.xml
-          file: nc_py_api/coverage.xml
+          path: nc_py_api/coverage.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -934,7 +934,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_sqlite_${{ matrix.nextcloud }}_client.xml
-          file: nc_py_api/coverage.xml
+          path: nc_py_api/coverage.xml
           if-no-files-found: error
 
       - name: Upload NC logs

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -912,17 +912,18 @@ jobs:
       - name: Download Coverage Artifacts
         uses: actions/download-artifact@v4
         with:
+          path: coverage
           pattern: coverage_*
           merge-multiple: true
 
       - name: debug
-        run: ls -la
+        run: ls -la && ls -la coverage
 
       - name: Upload report to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./
+          directory: coverage
           fail_ci_if_error: true
           verbose: true
 

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -908,6 +908,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Upload Coverage
     steps:
+      - uses: actions/checkout@v4
       - name: Download Coverage Artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -172,12 +172,6 @@ jobs:
           cd nc_py_api
           coverage combine && coverage xml && coverage html
 
-      - name: HTML coverage to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage_maria_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}
-          path: nc_py_api/htmlcov
-          if-no-files-found: error
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
@@ -331,13 +325,6 @@ jobs:
           cd nc_py_api
           coverage combine && coverage xml && coverage html
 
-      - name: HTML coverage to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage_pgsql_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}
-          path: nc_py_api/htmlcov
-          if-no-files-found: error
-
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -446,13 +433,6 @@ jobs:
           coverage combine && coverage xml && coverage html
         env:
           SKIP_NC_CLIENT_TESTS: 1
-
-      - name: HTML coverage to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage_oci_stable27_3.11_8.1
-          path: nc_py_api/htmlcov
-          if-no-files-found: error
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
@@ -620,13 +600,6 @@ jobs:
           timeout 3m tail --pid=$(cat /tmp/_install_models.pid) -f /dev/null
           cd nc_py_api
           coverage combine && coverage xml && coverage html
-
-      - name: HTML coverage to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage_maria_${{ matrix.nextcloud }}
-          path: nc_py_api/htmlcov
-          if-no-files-found: error
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
@@ -799,12 +772,6 @@ jobs:
           cd nc_py_api
           coverage combine && coverage xml && coverage html
 
-      - name: HTML coverage to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage_pgsql_${{ matrix.nextcloud }}
-          path: nc_py_api/htmlcov
-          if-no-files-found: error
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
@@ -923,13 +890,6 @@ jobs:
           SKIP_AA_TESTS: 1
           NPA_NC_CERT: ''
 
-      - name: HTML coverage to artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage_sqlite_${{ matrix.nextcloud }}
-          path: nc_py_api/htmlcov
-          if-no-files-found: error
-
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -964,7 +924,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          name: coverage-full
           fail_ci_if_error: true
           verbose: true
 

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -170,14 +170,13 @@ jobs:
           kill -15 $(cat /tmp/_install_models.pid)
           timeout 3m tail --pid=$(cat /tmp/_install_models.pid) -f /dev/null
           cd nc_py_api
-          coverage combine && coverage xml && coverage html
-
+          coverage combine && coverage xml -o coverage_maria_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: coverage_maria_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
-          path: nc_py_api/coverage.xml
+          path: nc_py_api/coverage_maria_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -323,13 +322,13 @@ jobs:
           kill -15 $(cat /tmp/_install_models.pid)
           timeout 3m tail --pid=$(cat /tmp/_install_models.pid) -f /dev/null
           cd nc_py_api
-          coverage combine && coverage xml && coverage html
+          coverage combine && coverage xml -o coverage_pgsql_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: coverage_pgsql_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
-          path: nc_py_api/coverage.xml
+          path: nc_py_api/coverage_pgsql_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -430,7 +429,7 @@ jobs:
         run: |
           coverage run --data-file=.coverage.ci -m pytest
           coverage run --data-file=.coverage.at_the_end -m pytest tests/_tests_at_the_end.py
-          coverage combine && coverage xml && coverage html
+          coverage combine && coverage xml -o coverage_oci_stable27_3.11_8.1.xml
         env:
           SKIP_NC_CLIENT_TESTS: 1
 
@@ -438,7 +437,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_oci_stable27_3.11_8.1.xml
-          path: nc_py_api/coverage.xml
+          path: nc_py_api/coverage_oci_stable27_3.11_8.1.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -599,13 +598,13 @@ jobs:
           kill -15 $(cat /tmp/_install_models.pid)
           timeout 3m tail --pid=$(cat /tmp/_install_models.pid) -f /dev/null
           cd nc_py_api
-          coverage combine && coverage xml && coverage html
+          coverage combine && coverage xml -o coverage_maria_${{ matrix.nextcloud }}.xml
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: coverage_maria_${{ matrix.nextcloud }}.xml
-          path: nc_py_api/coverage.xml
+          path: nc_py_api/coverage_maria_${{ matrix.nextcloud }}.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -770,14 +769,13 @@ jobs:
           kill -15 $(cat /tmp/_install_models.pid)
           timeout 3m tail --pid=$(cat /tmp/_install_models.pid) -f /dev/null
           cd nc_py_api
-          coverage combine && coverage xml && coverage html
-
+          coverage combine && coverage xml -o coverage_pgsql_${{ matrix.nextcloud }}.xml
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: coverage_pgsql_${{ matrix.nextcloud }}.xml
-          path: nc_py_api/coverage.xml
+          path: nc_py_api/coverage_pgsql_${{ matrix.nextcloud }}.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -883,9 +881,7 @@ jobs:
 
       - name: Generate coverage report
         working-directory: nc_py_api
-        run: |
-          coverage run -m pytest
-          coverage xml && coverage html
+        run: coverage run -m pytest && coverage xml -o coverage_sqlite_${{ matrix.nextcloud }}_client.xml
         env:
           SKIP_AA_TESTS: 1
           NPA_NC_CERT: ''
@@ -894,7 +890,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_sqlite_${{ matrix.nextcloud }}_client.xml
-          path: nc_py_api/coverage.xml
+          path: nc_py_api/coverage_sqlite_${{ matrix.nextcloud }}_client.xml
           if-no-files-found: error
 
       - name: Upload NC logs
@@ -916,6 +912,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: coverage_*
+          merge-multiple: true
 
       - name: debug
         run: ls -la

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -956,7 +956,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: coverage_*
-          merge-multiple: true
 
       - name: debug
         run: ls -la

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -922,6 +922,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./
           fail_ci_if_error: true
           verbose: true
 

--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -179,15 +179,12 @@ jobs:
           path: nc_py_api/htmlcov
           if-no-files-found: error
 
-      - name: Upload report to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload Codecov to artifacts
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: coverage_maria_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}
-          file: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-          working-directory: nc_py_api
+          name: coverage_maria_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
+          file: nc_py_api/coverage.xml
+          if-no-files-found: error
 
       - name: Upload NC logs
         if: always()
@@ -341,15 +338,12 @@ jobs:
           path: nc_py_api/htmlcov
           if-no-files-found: error
 
-      - name: Upload report to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload Codecov to artifacts
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: coverage_pgsql_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}
-          file: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-          working-directory: nc_py_api
+          name: coverage_pgsql_${{ matrix.nextcloud }}_${{ matrix.python }}_${{ matrix.php-version }}.xml
+          file: nc_py_api/coverage.xml
+          if-no-files-found: error
 
       - name: Upload NC logs
         if: always()
@@ -460,15 +454,12 @@ jobs:
           path: nc_py_api/htmlcov
           if-no-files-found: error
 
-      - name: Upload report to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload Codecov to artifacts
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: coverage_oci_stable27_3.11_8.1
-          file: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-          working-directory: nc_py_api
+          name: coverage_oci_stable27_3.11_8.1.xml
+          file: nc_py_api/coverage.xml
+          if-no-files-found: error
 
       - name: Upload NC logs
         if: always()
@@ -637,15 +628,12 @@ jobs:
           path: nc_py_api/htmlcov
           if-no-files-found: error
 
-      - name: Upload report to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload Codecov to artifacts
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: coverage_maria_${{ matrix.nextcloud }}
-          file: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-          working-directory: nc_py_api
+          name: coverage_maria_${{ matrix.nextcloud }}.xml
+          file: nc_py_api/coverage.xml
+          if-no-files-found: error
 
       - name: Upload NC logs
         if: always()
@@ -818,15 +806,12 @@ jobs:
           path: nc_py_api/htmlcov
           if-no-files-found: error
 
-      - name: Upload report to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload Codecov to artifacts
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: coverage_pgsql_${{ matrix.nextcloud }}
-          file: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-          working-directory: nc_py_api
+          name: coverage_pgsql_${{ matrix.nextcloud }}.xml
+          file: nc_py_api/coverage.xml
+          if-no-files-found: error
 
       - name: Upload NC logs
         if: always()
@@ -945,15 +930,12 @@ jobs:
           path: nc_py_api/htmlcov
           if-no-files-found: error
 
-      - name: Upload report to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload Codecov to artifacts
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: coverage_sqlite_${{ matrix.nextcloud }}_client
-          file: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-          working-directory: nc_py_api
+          name: coverage_sqlite_${{ matrix.nextcloud }}_client.xml
+          file: nc_py_api/coverage.xml
+          if-no-files-found: error
 
       - name: Upload NC logs
         if: always()
@@ -963,11 +945,35 @@ jobs:
           path: data/nextcloud.log
           if-no-files-found: warn
 
+  tests-upload-coverage:
+    needs: [tests-maria, tests-pgsql, tests-stable27-oci, tests-latest-maria, test-latest-pgsql, tests-client-sqlite]
+    permissions:
+      contents: none
+    runs-on: ubuntu-22.04
+    name: Upload Coverage
+    steps:
+      - name: Download Coverage Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage_*
+          merge-multiple: true
+
+      - name: debug
+        run: ls -la
+
+      - name: Upload report to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-full
+          fail_ci_if_error: true
+          verbose: true
+
   tests-success:
     permissions:
       contents: none
     runs-on: ubuntu-22.04
-    needs: [tests-maria, tests-pgsql, tests-stable27-oci, tests-latest-maria, test-latest-pgsql, tests-client-sqlite]
+    needs: [tests-upload-coverage]
     name: Tests-OK
     steps:
       - run: echo "Tests passed successfully"

--- a/nc_py_api/apps.py
+++ b/nc_py_api/apps.py
@@ -15,6 +15,11 @@ class ExAppInfo:
         self._raw_data = raw_data
 
     @property
+    def test_cov_ci(self) -> str:
+        """Coverage CI Action test."""
+        return "123"
+
+    @property
     def app_id(self) -> str:
         """`ID` of the application."""
         return self._raw_data["id"]

--- a/nc_py_api/apps.py
+++ b/nc_py_api/apps.py
@@ -15,11 +15,6 @@ class ExAppInfo:
         self._raw_data = raw_data
 
     @property
-    def test_cov_ci(self) -> str:
-        """Coverage CI Action test."""
-        return "123"
-
-    @property
     def app_id(self) -> str:
         """`ID` of the application."""
         return self._raw_data["id"]


### PR DESCRIPTION
Moves all coverage upload to a separate step, that can be easy rerun from GitHub UI.

Ref: https://github.com/codecov/codecov-action/issues/926

