### PR TITLE
`set_handlers`: heartbeat_handler/init_handler params rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.10.0 - 2024-02-0x]
+## [0.10.0 - 2024-02-14]
 
 ### Added
 
-- set_handlers: `models_to_fetch` can now accept direct links to a files to download. #217
-- DeclarativeSettings API for Nextcloud 29. #222
+- NextcloudApp: `set_handlers`: `models_to_fetch` can now accept direct links to a files to download. #217
+- NextcloudApp: DeclarativeSettings UI API for Nextcloud `29`. #222
 
 ### Changed
 
-- adjusted code related to changes in AppAPI `2.0.3` #216
+- NextcloudApp: adjusted code related to changes in AppAPI `2.0.3` #216
+- NextcloudApp: `set_handlers` **rework of optional parameters** see PR for information. #226
 
 ## [0.9.0 - 2024-01-25]
 

--- a/docs/NextcloudTalkBot.rst
+++ b/docs/NextcloudTalkBot.rst
@@ -36,7 +36,6 @@ Afterward, using FastAPI, you can define endpoints that will be invoked by Talk:
 
     @APP.post("/currency_talk_bot")
     async def currency_talk_bot(
-        _nc: Annotated[NextcloudApp, Depends(nc_app)],
         message: Annotated[talk_bot.TalkBotMessage, Depends(atalk_bot_msg)],
         background_tasks: BackgroundTasks,
     ):

--- a/examples/as_app/skeleton/lib/main.py
+++ b/examples/as_app/skeleton/lib/main.py
@@ -9,13 +9,13 @@ from nc_py_api.ex_app import AppAPIAuthMiddleware, LogLvl, run_app, set_handlers
 
 
 @asynccontextmanager
-async def lifespan(_app: FastAPI):
-    set_handlers(_app, enabled_handler)
+async def lifespan(app: FastAPI):
+    set_handlers(app, enabled_handler)
     yield
 
 
 APP = FastAPI(lifespan=lifespan)
-APP.add_middleware(AppAPIAuthMiddleware)
+APP.add_middleware(AppAPIAuthMiddleware)  # set global AppAPI authentication middleware
 
 
 def enabled_handler(enabled: bool, nc: NextcloudApp) -> str:

--- a/examples/as_app/skeleton/lib/main.py
+++ b/examples/as_app/skeleton/lib/main.py
@@ -5,16 +5,17 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from nc_py_api import NextcloudApp
-from nc_py_api.ex_app import LogLvl, run_app, set_handlers
+from nc_py_api.ex_app import AppAPIAuthMiddleware, LogLvl, run_app, set_handlers
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    set_handlers(APP, enabled_handler)
+    set_handlers(_app, enabled_handler)
     yield
 
 
 APP = FastAPI(lifespan=lifespan)
+APP.add_middleware(AppAPIAuthMiddleware)
 
 
 def enabled_handler(enabled: bool, nc: NextcloudApp) -> str:

--- a/examples/as_app/talk_bot/requirements.txt
+++ b/examples/as_app/talk_bot/requirements.txt
@@ -1,1 +1,1 @@
-nc_py_api[app]>=0.5.0
+nc_py_api[app]>=0.10.0

--- a/examples/as_app/talk_bot_ai/lib/main.py
+++ b/examples/as_app/talk_bot_ai/lib/main.py
@@ -10,9 +10,9 @@ from transformers import pipeline
 
 from nc_py_api import NextcloudApp, talk_bot
 from nc_py_api.ex_app import (
+    AppAPIAuthMiddleware,
     atalk_bot_msg,
     get_model_path,
-    nc_app,
     run_app,
     set_handlers,
 )
@@ -25,6 +25,7 @@ async def lifespan(_app: FastAPI):
 
 
 APP = FastAPI(lifespan=lifespan)
+APP.add_middleware(AppAPIAuthMiddleware)
 AI_BOT = talk_bot.TalkBot("/ai_talk_bot", "AI talk bot", "Usage: `@assistant What sounds do cats make?`")
 MODEL_NAME = "MBZUAI/LaMini-Flan-T5-783M"
 
@@ -40,7 +41,6 @@ def ai_talk_bot_process_request(message: talk_bot.TalkBotMessage):
 
 @APP.post("/ai_talk_bot")
 async def ai_talk_bot(
-    _nc: Annotated[NextcloudApp, Depends(nc_app)],
     message: Annotated[talk_bot.TalkBotMessage, Depends(atalk_bot_msg)],
     background_tasks: BackgroundTasks,
 ):

--- a/examples/as_app/talk_bot_ai/lib/main.py
+++ b/examples/as_app/talk_bot_ai/lib/main.py
@@ -19,8 +19,8 @@ from nc_py_api.ex_app import (
 
 
 @asynccontextmanager
-async def lifespan(_app: FastAPI):
-    set_handlers(APP, enabled_handler, models_to_fetch={MODEL_NAME: {}})
+async def lifespan(app: FastAPI):
+    set_handlers(app, enabled_handler, models_to_fetch={MODEL_NAME: {}})
     yield
 
 

--- a/examples/as_app/talk_bot_ai/requirements.txt
+++ b/examples/as_app/talk_bot_ai/requirements.txt
@@ -1,4 +1,4 @@
-nc_py_api[app]>=0.7.0
+nc_py_api[app]>=0.10.0
 transformers>=4.33
 torch
 torchvision

--- a/examples/as_app/to_gif/lib/main.py
+++ b/examples/as_app/to_gif/lib/main.py
@@ -3,17 +3,22 @@
 import tempfile
 from contextlib import asynccontextmanager
 from os import path
-from typing import Annotated
 
 import cv2
 import imageio
 import numpy
-from fastapi import BackgroundTasks, Depends, FastAPI
+from fastapi import BackgroundTasks, FastAPI
 from pygifsicle import optimize
 from requests import Response
 
 from nc_py_api import FsNode, NextcloudApp
-from nc_py_api.ex_app import LogLvl, UiActionFileInfo, nc_app, run_app, set_handlers
+from nc_py_api.ex_app import (
+    AppAPIAuthMiddleware,
+    LogLvl,
+    UiActionFileInfo,
+    run_app,
+    set_handlers,
+)
 
 
 @asynccontextmanager
@@ -23,9 +28,11 @@ async def lifespan(_app: FastAPI):
 
 
 APP = FastAPI(lifespan=lifespan)
+APP.add_middleware(AppAPIAuthMiddleware)
 
 
-def convert_video_to_gif(input_file: FsNode, nc: NextcloudApp):
+def convert_video_to_gif(input_file: FsNode):
+    nc = NextcloudApp()
     save_path = path.splitext(input_file.user_path)[0] + ".gif"
     nc.log(LogLvl.WARNING, f"Processing:{input_file.user_path} -> {save_path}")
     try:
@@ -70,10 +77,9 @@ def convert_video_to_gif(input_file: FsNode, nc: NextcloudApp):
 @APP.post("/video_to_gif")
 async def video_to_gif(
     file: UiActionFileInfo,
-    nc: Annotated[NextcloudApp, Depends(nc_app)],
     background_tasks: BackgroundTasks,
 ):
-    background_tasks.add_task(convert_video_to_gif, file.to_fs_node(), nc)
+    background_tasks.add_task(convert_video_to_gif, file.to_fs_node())
     return Response()
 
 

--- a/examples/as_app/to_gif/lib/main.py
+++ b/examples/as_app/to_gif/lib/main.py
@@ -22,8 +22,8 @@ from nc_py_api.ex_app import (
 
 
 @asynccontextmanager
-async def lifespan(_app: FastAPI):
-    set_handlers(APP, enabled_handler)
+async def lifespan(app: FastAPI):
+    set_handlers(app, enabled_handler)
     yield
 
 

--- a/examples/as_app/to_gif/requirements.txt
+++ b/examples/as_app/to_gif/requirements.txt
@@ -1,4 +1,4 @@
-nc_py_api[app]>=0.7.0
+nc_py_api[app]>=0.10.0
 pygifsicle
 imageio
 opencv-python

--- a/examples/as_app/ui_example/lib/main.py
+++ b/examples/as_app/ui_example/lib/main.py
@@ -18,8 +18,8 @@ from nc_py_api.ex_app import (
 
 
 @asynccontextmanager
-async def lifespan(_app: FastAPI):
-    set_handlers(APP, enabled_handler)
+async def lifespan(app: FastAPI):
+    set_handlers(app, enabled_handler)
     yield
 
 

--- a/examples/as_app/ui_example/lib/main.py
+++ b/examples/as_app/ui_example/lib/main.py
@@ -1,18 +1,17 @@
 """Example with which we test UI elements."""
 
 import random
-import typing
 from contextlib import asynccontextmanager
 
-from fastapi import Depends, FastAPI, responses
+from fastapi import FastAPI, responses
 from pydantic import BaseModel
 
 from nc_py_api import NextcloudApp
 from nc_py_api.ex_app import (
+    AppAPIAuthMiddleware,
     SettingsField,
     SettingsFieldType,
     SettingsForm,
-    nc_app,
     run_app,
     set_handlers,
 )
@@ -25,6 +24,7 @@ async def lifespan(_app: FastAPI):
 
 
 APP = FastAPI(lifespan=lifespan)
+APP.add_middleware(AppAPIAuthMiddleware)
 
 SETTINGS_EXAMPLE = SettingsForm(
     id="settings_example",
@@ -170,7 +170,6 @@ class Button1Format(BaseModel):
 
 @APP.post("/verify_initial_value")
 async def verify_initial_value(
-    _nc: typing.Annotated[NextcloudApp, Depends(nc_app)],
     input1: Button1Format,
 ):
     print("Old value: ", input1.initial_value)
@@ -190,7 +189,6 @@ class FileInfo(BaseModel):
 
 @APP.post("/nextcloud_file")
 async def nextcloud_file(
-    _nc: typing.Annotated[NextcloudApp, Depends(nc_app)],
     args: dict,
 ):
     print(args["file_info"])

--- a/examples/as_app/ui_example/requirements.txt
+++ b/examples/as_app/ui_example/requirements.txt
@@ -1,1 +1,1 @@
-nc_py_api[app]>=0.5.1
+nc_py_api[app]>=0.10.0

--- a/nc_py_api/ex_app/integration_fastapi.py
+++ b/nc_py_api/ex_app/integration_fastapi.py
@@ -32,16 +32,14 @@ from .misc import persistent_storage
 def nc_app(request: HTTPConnection) -> NextcloudApp:
     """Authentication handler for requests from Nextcloud to the application."""
     nextcloud_app = NextcloudApp(**__nc_app(request))
-    if not [i for i in getattr(request.app, "user_middleware", []) if i.cls == AppAPIAuthMiddleware]:
-        _request_sign_check(request, nextcloud_app)
+    __request_sign_check_if_needed(request, nextcloud_app)
     return nextcloud_app
 
 
 def anc_app(request: HTTPConnection) -> AsyncNextcloudApp:
     """Async Authentication handler for requests from Nextcloud to the application."""
     nextcloud_app = AsyncNextcloudApp(**__nc_app(request))
-    if not [i for i in getattr(request.app, "user_middleware", []) if i.cls == AppAPIAuthMiddleware]:
-        _request_sign_check(request, nextcloud_app)
+    __request_sign_check_if_needed(request, nextcloud_app)
     return nextcloud_app
 
 
@@ -201,6 +199,11 @@ def __nc_app(request: HTTPConnection) -> dict:
     )[0]
     request_id = request.headers.get("AA-REQUEST-ID", None)
     return {"user": user, "headers": {"AA-REQUEST-ID": request_id} if request_id else {}}
+
+
+def __request_sign_check_if_needed(request: HTTPConnection, nextcloud_app: NextcloudApp | AsyncNextcloudApp) -> None:
+    if not [i for i in getattr(request.app, "user_middleware", []) if i.cls == AppAPIAuthMiddleware]:
+        _request_sign_check(request, nextcloud_app)
 
 
 def _request_sign_check(request: HTTPConnection, nextcloud_app: NextcloudApp | AsyncNextcloudApp) -> None:

--- a/nc_py_api/ex_app/integration_fastapi.py
+++ b/nc_py_api/ex_app/integration_fastapi.py
@@ -204,8 +204,11 @@ def __nc_app(request: HTTPConnection) -> dict:
 
 
 def _request_sign_check(request: HTTPConnection, nextcloud_app: NextcloudApp | AsyncNextcloudApp) -> None:
-    if not nextcloud_app.request_sign_check(request):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    try:
+        nextcloud_app._session.sign_check(request)  # noqa pylint: disable=protected-access
+    except ValueError as e:
+        print(e)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED) from None
 
 
 class AppAPIAuthMiddleware:

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -4,7 +4,6 @@ import typing
 from abc import ABC
 
 from httpx import Headers
-from starlette.requests import HTTPConnection
 
 from ._exceptions import NextcloudExceptionNotFound
 from ._misc import check_capabilities, require_capabilities
@@ -386,20 +385,6 @@ class NextcloudApp(_NextcloudBasic):
             return False
         return True
 
-    def request_sign_check(self, request: HTTPConnection) -> bool:
-        """Verifies the signature and validity of an incoming request from the Nextcloud.
-
-        :param request: The `Starlette request <https://www.starlette.io/requests/>`_
-
-        .. note:: In most cases ``nc: Annotated[NextcloudApp, Depends(nc_app)]`` should be used.
-        """
-        try:
-            self._session.sign_check(request)
-        except ValueError as e:
-            print(e)
-            return False
-        return True
-
     def set_init_status(self, progress: int, error: str = "") -> None:
         """Sets state of the app initialization.
 
@@ -514,20 +499,6 @@ class AsyncNextcloudApp(_AsyncNextcloudBasic):
         try:
             await self._session.ocs("DELETE", f"{self._session.ae_url}/talk_bot", json=params)
         except NextcloudExceptionNotFound:
-            return False
-        return True
-
-    def request_sign_check(self, request: HTTPConnection) -> bool:
-        """Verifies the signature and validity of an incoming request from the Nextcloud.
-
-        :param request: The `Starlette request <https://www.starlette.io/requests/>`_
-
-        .. note:: In most cases ``nc: Annotated[NextcloudApp, Depends(nc_app)]`` should be used.
-        """
-        try:
-            self._session.sign_check(request)
-        except ValueError as e:
-            print(e)
             return False
         return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "fastapi>=0.101",
-  "httpx>=0.24.1",
+  "fastapi>=0.109.2",
+  "httpx>=0.25.2",
   "pydantic>=2.1.1",
   "python-dotenv>=1",
   "xmltodict>=0.13",

--- a/tests/_install.py
+++ b/tests/_install.py
@@ -1,7 +1,6 @@
 from contextlib import asynccontextmanager
-from typing import Annotated
 
-from fastapi import Depends, FastAPI
+from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from nc_py_api import NextcloudApp, ex_app
@@ -9,18 +8,16 @@ from nc_py_api import NextcloudApp, ex_app
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    ex_app.set_handlers(APP, enabled_handler, heartbeat_callback, init_handler=init_handler)
+    ex_app.set_handlers(APP, enabled_handler)
     yield
 
 
 APP = FastAPI(lifespan=lifespan)
+APP.add_middleware(ex_app.AppAPIAuthMiddleware)
 
 
 @APP.put("/sec_check")
-def sec_check(
-    value: int,
-    _nc: Annotated[NextcloudApp, Depends(ex_app.nc_app)],
-):
+def sec_check(value: int):
     print(value, flush=True)
     return JSONResponse(content={"error": ""}, status_code=200)
 
@@ -32,14 +29,6 @@ def enabled_handler(enabled: bool, nc: NextcloudApp) -> str:
     else:
         nc.log(ex_app.LogLvl.WARNING, f"Bye bye from {nc.app_cfg.app_name} :(")
     return ""
-
-
-def init_handler(nc: NextcloudApp):
-    nc.set_init_status(100)
-
-
-def heartbeat_callback():
-    return "ok"
 
 
 if __name__ == "__main__":

--- a/tests/_install.py
+++ b/tests/_install.py
@@ -14,11 +14,13 @@ async def lifespan(_app: FastAPI):
 
 
 APP = FastAPI(lifespan=lifespan)
-APP.add_middleware(ex_app.AppAPIAuthMiddleware, disable_for=["/init"])
 
 
 @APP.put("/sec_check")
-def sec_check(value: int):
+def sec_check(
+    value: int,
+    _nc: typing.Annotated[NextcloudApp, Depends(ex_app.nc_app)],
+):
     print(value, flush=True)
     return JSONResponse(content={"error": ""}, status_code=200)
 

--- a/tests/_install_async.py
+++ b/tests/_install_async.py
@@ -8,7 +8,7 @@ from nc_py_api import AsyncNextcloudApp, ex_app
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    ex_app.set_handlers(APP, enabled_handler, heartbeat_callback, init_handler=init_handler)
+    ex_app.set_handlers(APP, enabled_handler)
     yield
 
 
@@ -17,9 +17,7 @@ APP.add_middleware(ex_app.AppAPIAuthMiddleware)
 
 
 @APP.put("/sec_check")
-async def sec_check(
-    value: int,
-):
+async def sec_check(value: int):
     print(value, flush=True)
     return JSONResponse(content={"error": ""}, status_code=200)
 
@@ -31,14 +29,6 @@ async def enabled_handler(enabled: bool, nc: AsyncNextcloudApp) -> str:
     else:
         await nc.log(ex_app.LogLvl.WARNING, f"Bye bye from {nc.app_cfg.app_name} :(")
     return ""
-
-
-async def init_handler(nc: AsyncNextcloudApp):
-    await nc.set_init_status(100)
-
-
-async def heartbeat_callback():
-    return "ok"
 
 
 if __name__ == "__main__":

--- a/tests/_install_async.py
+++ b/tests/_install_async.py
@@ -14,12 +14,12 @@ async def lifespan(_app: FastAPI):
 
 
 APP = FastAPI(lifespan=lifespan)
+APP.add_middleware(ex_app.AppAPIAuthMiddleware)
 
 
 @APP.put("/sec_check")
 async def sec_check(
     value: int,
-    _nc: typing.Annotated[AsyncNextcloudApp, Depends(ex_app.anc_app)],
 ):
     print(value, flush=True)
     return JSONResponse(content={"error": ""}, status_code=200)

--- a/tests/_install_async.py
+++ b/tests/_install_async.py
@@ -14,11 +14,13 @@ async def lifespan(_app: FastAPI):
 
 
 APP = FastAPI(lifespan=lifespan)
-APP.add_middleware(ex_app.AppAPIAuthMiddleware, disable_for=["/init"])
 
 
 @APP.put("/sec_check")
-async def sec_check(value: int):
+async def sec_check(
+    value: int,
+    _nc: typing.Annotated[AsyncNextcloudApp, Depends(ex_app.anc_app)],
+):
     print(value, flush=True)
     return JSONResponse(content={"error": ""}, status_code=200)
 

--- a/tests/_install_async.py
+++ b/tests/_install_async.py
@@ -1,6 +1,7 @@
+import typing
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import BackgroundTasks, Depends, FastAPI
 from fastapi.responses import JSONResponse
 
 from nc_py_api import AsyncNextcloudApp, ex_app
@@ -8,18 +9,31 @@ from nc_py_api import AsyncNextcloudApp, ex_app
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    ex_app.set_handlers(APP, enabled_handler)
+    ex_app.set_handlers(APP, enabled_handler, default_init=False)
     yield
 
 
 APP = FastAPI(lifespan=lifespan)
-APP.add_middleware(ex_app.AppAPIAuthMiddleware)
+APP.add_middleware(ex_app.AppAPIAuthMiddleware, disable_for=["/init"])
 
 
 @APP.put("/sec_check")
 async def sec_check(value: int):
     print(value, flush=True)
     return JSONResponse(content={"error": ""}, status_code=200)
+
+
+async def init_handler_background(nc: AsyncNextcloudApp):
+    await nc.set_init_status(100)
+
+
+@APP.post("/init")
+async def init_handler(
+    background_tasks: BackgroundTasks,
+    nc: typing.Annotated[AsyncNextcloudApp, Depends(ex_app.anc_app)],
+):
+    background_tasks.add_task(init_handler_background, nc)
+    return JSONResponse(content={}, status_code=200)
 
 
 async def enabled_handler(enabled: bool, nc: AsyncNextcloudApp) -> str:

--- a/tests/_talk_bot.py
+++ b/tests/_talk_bot.py
@@ -6,9 +6,10 @@ import pytest
 from fastapi import BackgroundTasks, Depends, FastAPI, Request, Response
 
 from nc_py_api import NextcloudApp, talk_bot
-from nc_py_api.ex_app import nc_app, run_app, talk_bot_msg
+from nc_py_api.ex_app import AppAPIAuthMiddleware, nc_app, run_app, talk_bot_msg
 
 APP = FastAPI()
+APP.add_middleware(AppAPIAuthMiddleware, disable_for=["reset_bot_secret"])
 COVERAGE_BOT = talk_bot.TalkBot("/talk_bot_coverage", "Coverage bot", "Desc")
 
 

--- a/tests/_talk_bot_async.py
+++ b/tests/_talk_bot_async.py
@@ -6,9 +6,10 @@ import pytest
 from fastapi import BackgroundTasks, Depends, FastAPI, Request, Response
 
 from nc_py_api import AsyncNextcloudApp, talk_bot
-from nc_py_api.ex_app import anc_app, atalk_bot_msg, run_app
+from nc_py_api.ex_app import AppAPIAuthMiddleware, anc_app, atalk_bot_msg, run_app
 
 APP = FastAPI()
+APP.add_middleware(AppAPIAuthMiddleware, disable_for=["reset_bot_secret"])
 COVERAGE_BOT = talk_bot.AsyncTalkBot("/talk_bot_coverage", "Coverage bot", "Desc")
 
 

--- a/tests/actual_tests/nc_app_test.py
+++ b/tests/actual_tests/nc_app_test.py
@@ -76,4 +76,4 @@ async def test_set_user_same_value_async(anc_app):
 
 def test_set_handlers_invalid_param(nc_any):
     with pytest.raises(ValueError):
-        set_handlers(None, None, init_handler=set_handlers, models_to_fetch={"some": {}})  # noqa
+        set_handlers(None, None, default_init=False, models_to_fetch={"some": {}})  # noqa


### PR DESCRIPTION
Old `set_handlers`
```python3

def set_handlers(
    fast_api_app: FastAPI,
    enabled_handler: typing.Callable[[bool, AsyncNextcloudApp | NextcloudApp], typing.Awaitable[str] | str],
    heartbeat_handler: typing.Callable[[], typing.Awaitable[str] | str] | None = None,
    init_handler: typing.Callable[[AsyncNextcloudApp | NextcloudApp], typing.Awaitable[None] | None] | None = None,
    models_to_fetch: dict[str, dict] | None = None,
    map_app_static: bool = True,
):
```


New `set_handlers`:
```python3

def set_handlers(
    fast_api_app: FastAPI,
    enabled_handler: typing.Callable[[bool, AsyncNextcloudApp | NextcloudApp], typing.Awaitable[str] | str],
    default_heartbeat: bool = True,
    default_init: bool = True,
    models_to_fetch: dict[str, dict] | None = None,
    map_app_static: bool = True,
):
```

Main change is now if you wish to define your own `/init` or `/heartbeat` just pass ``False`` to **set_handlers** and that's all, define those two routes or any of them.

This greatly simplifies a code, to be easy maintainable in future.

And from now documentation precisely says that recommend way is to use global auth `AppAPIAuthMiddleware`, to make developing of ExApps more simple.

Also `disable_for` parameter to AppAPIAuthMiddleware is now in `fnmatch` so for debug builds you just can pass `["*"]` to disable auth.