### PR TITLE
restore old file_version tests, skip them on PGSQL

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -200,6 +200,7 @@ jobs:
             php-version: "8.2"
     env:
       NC_dbname: nextcloud_abz
+      DATABASE_PGSQL: 1
     timeout-minutes: 60
 
     services:
@@ -637,6 +638,7 @@ jobs:
         nextcloud: [ 'stable27', 'stable28', 'master' ]
     env:
       NC_dbname: nextcloud_abz
+      DATABASE_PGSQL: 1
     timeout-minutes: 60
 
     services:

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,12 @@ help:
 	@echo "  "
 	@echo "  register27          register nc_py_api for Nextcloud 27"
 	@echo "  register28          register nc_py_api for Nextcloud 28"
+	@echo "  register29          register nc_py_api for Nextcloud 29"
 	@echo "  register            register nc_py_api for Nextcloud Last"
 	@echo "  "
 	@echo "  tests27             run nc_py_api tests for Nextcloud 27"
 	@echo "  tests28             run nc_py_api tests for Nextcloud 28"
+	@echo "  tests29             run nc_py_api tests for Nextcloud 29"
 	@echo "  tests               run nc_py_api tests for Nextcloud Last"
 
 .PHONY: register27
@@ -34,6 +36,10 @@ register27:
 .PHONY: register28
 register28:
 	/bin/sh scripts/dev_register.sh master-stable28-1 stable28.local
+
+.PHONY: register29
+register29:
+	/bin/sh scripts/dev_register.sh master-stable29-1 stable28.local
 
 .PHONY: register
 register:
@@ -46,6 +52,10 @@ tests27:
 .PHONY: tests28
 tests28:
 	NEXTCLOUD_URL=http://stable28.local python3 -m pytest
+
+.PHONY: tests29
+tests29:
+	NEXTCLOUD_URL=http://stable29.local python3 -m pytest
 
 .PHONY: tests
 tests:

--- a/tests/actual_tests/files_test.py
+++ b/tests/actual_tests/files_test.py
@@ -1,7 +1,6 @@
 import contextlib
 import math
 import os
-import time
 import zipfile
 from datetime import datetime
 from io import BytesIO
@@ -1055,45 +1054,51 @@ async def test_trashbin_async(anc_any, file_path):
     assert not r
 
 
-def test_file_versions(nc_any):
+@pytest.mark.skipif(os.environ.get("DATABASE_PGSQL", "0") == "1", reason="Fails on the PGSQL")
+@pytest.mark.parametrize(
+    "dest_path",
+    ("/test_dir_tmp/file_versions.txt", "/test_dir_tmp/file_versions-ä.txt", "test_dir_tmp/file_versions-1##3"),
+)
+def test_file_versions(nc_any, dest_path):
     if nc_any.check_capabilities("files.versioning"):
         pytest.skip("Need 'Versions' App to be enabled.")
-    dest_path = "/test_dir_tmp/file_versions-ä.txt"
-    nc_any.files.delete(dest_path, not_fail=True)
-    nc_any.files.upload(dest_path, content=b"22")
-    time.sleep(2.0)
-    new_file = nc_any.files.upload(dest_path, content=b"333")
-    time.sleep(2.0)
-    versions = nc_any.files.get_versions(new_file)
-    assert versions
-    version_str = str(versions[0])
-    assert version_str.find("File version") != -1
-    assert version_str.find("bytes size") != -1
-    time.sleep(2.0)
-    nc_any.files.restore_version(versions[0])
-    time.sleep(2.0)
-    assert nc_any.files.download(new_file) == b"22"
+    for i in (0, 1):
+        nc_any.files.delete(dest_path, not_fail=True)
+        nc_any.files.upload(dest_path, content=b"22")
+        new_file = nc_any.files.upload(dest_path, content=b"333")
+        if i:
+            new_file = nc_any.files.by_id(new_file)
+        versions = nc_any.files.get_versions(new_file)
+        assert versions
+        version_str = str(versions[0])
+        assert version_str.find("File version") != -1
+        assert version_str.find("bytes size") != -1
+        nc_any.files.restore_version(versions[0])
+        assert nc_any.files.download(new_file) == b"22"
 
 
+@pytest.mark.skipif(os.environ.get("DATABASE_PGSQL", "0") == "1", reason="Fails on the PGSQL")
 @pytest.mark.asyncio(scope="session")
-async def test_file_versions_async(anc_any):
+@pytest.mark.parametrize(
+    "dest_path",
+    ("/test_dir_tmp/file_versions.txt", "/test_dir_tmp/file_versions-ä.txt", "test_dir_tmp/file_versions-1##3"),
+)
+async def test_file_versions_async(anc_any, dest_path):
     if await anc_any.check_capabilities("files.versioning"):
         pytest.skip("Need 'Versions' App to be enabled.")
-    dest_path = "/test_dir_tmp/file_versions-ä-async.txt"
-    await anc_any.files.delete(dest_path, not_fail=True)
-    await anc_any.files.upload(dest_path, content=b"22")
-    time.sleep(2.0)
-    new_file = await anc_any.files.upload(dest_path, content=b"333")
-    time.sleep(2.0)
-    versions = await anc_any.files.get_versions(new_file)
-    assert versions
-    version_str = str(versions[0])
-    assert version_str.find("File version") != -1
-    assert version_str.find("bytes size") != -1
-    time.sleep(2.0)
-    await anc_any.files.restore_version(versions[0])
-    time.sleep(2.0)
-    assert await anc_any.files.download(new_file) == b"22"
+    for i in (0, 1):
+        await anc_any.files.delete(dest_path, not_fail=True)
+        await anc_any.files.upload(dest_path, content=b"22")
+        new_file = await anc_any.files.upload(dest_path, content=b"333")
+        if i:
+            new_file = await anc_any.files.by_id(new_file)
+        versions = await anc_any.files.get_versions(new_file)
+        assert versions
+        version_str = str(versions[0])
+        assert version_str.find("File version") != -1
+        assert version_str.find("bytes size") != -1
+        await anc_any.files.restore_version(versions[0])
+        assert await anc_any.files.download(new_file) == b"22"
 
 
 def test_create_update_delete_tag(nc_any):


### PR DESCRIPTION
Restored the old tests for the file versions, because that commit with optimization of working with file versions in the Nextcloud server repository was backported on the NC 27, 28 versions of the server - I simply disabled this test on the PGSQL database, where these tests fails.
