### PR TITLE
fixed `nc.files.makedirs` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0 - 2024-08-xx]
+
+### Fixed
+
+- `nc.files.makedirs` not working properly on Windows. #280 Thanks to @Wuli6
+
 ## [0.15.1 - 2024-07-30]
 
 ### Fixed

--- a/nc_py_api/_version.py
+++ b/nc_py_api/_version.py
@@ -1,3 +1,3 @@
 """Version of nc_py_api."""
 
-__version__ = "0.15.1"
+__version__ = "0.16.0.dev0"

--- a/nc_py_api/files/files.py
+++ b/nc_py_api/files/files.py
@@ -174,7 +174,7 @@ class FilesAPI:
         path = path.lstrip("/")
         result = None
         for i in Path(path).parts:
-            _path = os.path.join(_path, i)
+            _path = f"{_path}/{i}"
             if not exist_ok:
                 result = self.mkdir(_path)
             else:


### PR DESCRIPTION
Reference: #280