### PR TITLE
Suppress exceptions in `nc.log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.17.1 - 2024-09-06]
+
+### Fixed
+
+- NextcloudApp: `nc.log` now suppresses all exceptions to safe call it anywhere in your app.
+
 ## [0.17.0 - 2024-09-05]
 
 ### Added

--- a/nc_py_api/_version.py
+++ b/nc_py_api/_version.py
@@ -1,3 +1,3 @@
 """Version of nc_py_api."""
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -352,10 +352,13 @@ class NextcloudApp(_NextcloudBasic):
         """Writes log to the Nextcloud log file."""
         if self.check_capabilities("app_api"):
             return
-        if int(log_lvl) < self.capabilities["app_api"].get("loglevel", 0):
+        int_log_lvl = int(log_lvl)
+        if int_log_lvl < 0 or int_log_lvl > 4:
+            raise ValueError("Invalid `log_lvl` value")
+        if int_log_lvl < self.capabilities["app_api"].get("loglevel", 0):
             return
         with contextlib.suppress(Exception):
-            self._session.ocs("POST", f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content})
+            self._session.ocs("POST", f"{self._session.ae_url}/log", json={"level": int_log_lvl, "message": content})
 
     def users_list(self) -> list[str]:
         """Returns list of users on the Nextcloud instance."""
@@ -483,11 +486,14 @@ class AsyncNextcloudApp(_AsyncNextcloudBasic):
         """Writes log to the Nextcloud log file."""
         if await self.check_capabilities("app_api"):
             return
-        if int(log_lvl) < (await self.capabilities)["app_api"].get("loglevel", 0):
+        int_log_lvl = int(log_lvl)
+        if int_log_lvl < 0 or int_log_lvl > 4:
+            raise ValueError("Invalid `log_lvl` value")
+        if int_log_lvl < (await self.capabilities)["app_api"].get("loglevel", 0):
             return
         with contextlib.suppress(Exception):
             await self._session.ocs(
-                "POST", f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content}
+                "POST", f"{self._session.ae_url}/log", json={"level": int_log_lvl, "message": content}
             )
 
     async def users_list(self) -> list[str]:

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -354,7 +354,8 @@ class NextcloudApp(_NextcloudBasic):
             return
         if int(log_lvl) < self.capabilities["app_api"].get("loglevel", 0):
             return
-        self._session.ocs("POST", f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content})
+        with contextlib.suppress(Exception):
+            self._session.ocs("POST", f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content})
 
     def users_list(self) -> list[str]:
         """Returns list of users on the Nextcloud instance."""
@@ -484,7 +485,10 @@ class AsyncNextcloudApp(_AsyncNextcloudBasic):
             return
         if int(log_lvl) < (await self.capabilities)["app_api"].get("loglevel", 0):
             return
-        await self._session.ocs("POST", f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content})
+        with contextlib.suppress(Exception):
+            await self._session.ocs(
+                "POST", f"{self._session.ae_url}/log", json={"level": int(log_lvl), "message": content}
+            )
 
     async def users_list(self) -> list[str]:
         """Returns list of users on the Nextcloud instance."""

--- a/tests/actual_tests/logs_test.py
+++ b/tests/actual_tests/logs_test.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 
-from nc_py_api import NextcloudException
 from nc_py_api.ex_app import LogLvl
 
 
@@ -34,13 +33,13 @@ async def test_loglvl_str_async(anc_app):
 
 
 def test_invalid_log_level(nc_app):
-    with pytest.raises(NextcloudException):
+    with pytest.raises(ValueError):
         nc_app.log(5, "wrong log level")  # noqa
 
 
 @pytest.mark.asyncio(scope="session")
 async def test_invalid_log_level_async(anc_app):
-    with pytest.raises(NextcloudException):
+    with pytest.raises(ValueError):
         await anc_app.log(5, "wrong log level")  # noqa
 
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Suppress all exceptions during `nc.log`

It's strange that I didn't do this before, without it we won't be able to use logging during exception handling.