### PR TITLE
Fix user and user_path in FSNode for subpath deployments

### DIFF
--- a/nc_py_api/files/__init__.py
+++ b/nc_py_api/files/__init__.py
@@ -5,11 +5,17 @@ import datetime
 import email.utils
 import enum
 import os
+import re
 import warnings
 
 from pydantic import BaseModel
 
 from .. import _misc
+
+user_regex = re.compile(r".*?files/([^/]+)/")
+"""Regex for evaluating user from path string; instantiated once on import."""
+user_path_regex = re.compile(r"files/([^/]+)/")
+"""Regex for evaluating user path from oath string; instantiated once on import."""
 
 
 class LockType(enum.IntEnum):
@@ -218,12 +224,12 @@ class FsNode:
     @property
     def user(self) -> str:
         """Returns user ID extracted from the `full_path`."""
-        return self.full_path.lstrip("/").split("/", maxsplit=2)[1]
+        return user_regex.findall(self.full_path)[0]
 
     @property
     def user_path(self) -> str:
         """Returns path relative to the user's root directory."""
-        return self.full_path.lstrip("/").split("/", maxsplit=2)[-1]
+        return user_path_regex.sub("", self.full_path, count=1)
 
     @property
     def is_shared(self) -> bool:

--- a/nc_py_api/files/__init__.py
+++ b/nc_py_api/files/__init__.py
@@ -14,7 +14,7 @@ from .. import _misc
 
 user_regex = re.compile(r"(?:files|trashbin|versions)/([^/]+)/")
 """Regex for evaluating user from full path string; instantiated once on import."""
-user_path_regex = re.compile(r".*?(files|trashbini|versions)/([^/]+)/")
+user_path_regex = re.compile(r".*?(files|trashbin|versions)/([^/]+)/")
 """Regex for evaluating user path from full path string; instantiated once on import."""
 
 

--- a/nc_py_api/files/__init__.py
+++ b/nc_py_api/files/__init__.py
@@ -12,9 +12,9 @@ from pydantic import BaseModel
 
 from .. import _misc
 
-user_regex = re.compile(r".*?files/([^/]+)/")
+user_regex = re.compile(r"files/([^/]+)/")
 """Regex for evaluating user from full path string; instantiated once on import."""
-user_path_regex = re.compile(r"files/([^/]+)/")
+user_path_regex = re.compile(r".*?files/([^/]+)/")
 """Regex for evaluating user path from full path string; instantiated once on import."""
 
 

--- a/nc_py_api/files/__init__.py
+++ b/nc_py_api/files/__init__.py
@@ -12,9 +12,9 @@ from pydantic import BaseModel
 
 from .. import _misc
 
-user_regex = re.compile(r"files/([^/]+)/")
+user_regex = re.compile(r"(?:files|trashbin|versions)/([^/]+)/")
 """Regex for evaluating user from full path string; instantiated once on import."""
-user_path_regex = re.compile(r".*?files/([^/]+)/")
+user_path_regex = re.compile(r".*?(files|trashbini|versions)/([^/]+)/")
 """Regex for evaluating user path from full path string; instantiated once on import."""
 
 

--- a/nc_py_api/files/__init__.py
+++ b/nc_py_api/files/__init__.py
@@ -13,9 +13,9 @@ from pydantic import BaseModel
 from .. import _misc
 
 user_regex = re.compile(r".*?files/([^/]+)/")
-"""Regex for evaluating user from path string; instantiated once on import."""
+"""Regex for evaluating user from full path string; instantiated once on import."""
 user_path_regex = re.compile(r"files/([^/]+)/")
-"""Regex for evaluating user path from oath string; instantiated once on import."""
+"""Regex for evaluating user path from full path string; instantiated once on import."""
 
 
 class LockType(enum.IntEnum):


### PR DESCRIPTION
Fixes #296  .

Changes proposed in this pull request:

 * Regex instantiated on import for performance
 * Regex to fetch accurate user path regardless of subpath
 * Regex to fetch accurate user regardless of subpath

Tested against three Nextcloud instances, with or without /nextcloud and index.php in the path.  