### PR TITLE
CI fix: app_api is now bundled app from NC 30.0.1

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -106,7 +106,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: apps/app_api
-          repository: cloud-py-api/app_api
+          repository: nextcloud/app_api
+          ref: stable29
 
       - name: Install AppAPI
         run: |
@@ -248,7 +249,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: apps/app_api
-          repository: cloud-py-api/app_api
+          repository: nextcloud/app_api
+          ref: stable29
 
       - name: Install AppAPI
         run: |
@@ -390,7 +392,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: apps/app_api
-          repository: cloud-py-api/app_api
+          repository: nextcloud/app_api
+          ref: stable29
 
       - name: Install AppAPI
         run: |
@@ -525,10 +528,19 @@ jobs:
         run: python3 -m pip -v install ".[dev]"
 
       - name: Checkout AppAPI
+        if: ${{ matrix.nextcloud != 'master' }}
         uses: actions/checkout@v4
         with:
           path: apps/app_api
-          repository: cloud-py-api/app_api
+          repository: nextcloud/app_api
+          ref: stable29
+
+      - name: Checkout AppAPI
+        if: ${{ matrix.nextcloud == 'master' }}
+        uses: actions/checkout@v4
+        with:
+          path: apps/app_api
+          repository: nextcloud/app_api
 
       - name: Install AppAPI
         run: |
@@ -692,10 +704,19 @@ jobs:
         run: python3 -m pip -v install ".[dev]"
 
       - name: Checkout AppAPI
+        if: ${{ matrix.nextcloud != 'master' }}
         uses: actions/checkout@v4
         with:
           path: apps/app_api
-          repository: cloud-py-api/app_api
+          repository: nextcloud/app_api
+          ref: stable29
+
+      - name: Checkout AppAPI
+        if: ${{ matrix.nextcloud == 'master' }}
+        uses: actions/checkout@v4
+        with:
+          path: apps/app_api
+          repository: nextcloud/app_api
 
       - name: Install AppAPI
         run: |


### PR DESCRIPTION
Since Nextcloud 30.0.1 version, AppAPI has become built into the server, so now the `stable29` branch is the branch for Nextcloud `28` and `29`, and the `main` branch corresponds to the `master` branch of the server, and branch 30 is there for Nextcloud `30.0.1+`

It is tough..