### PR TITLE
Fix of download_directory_as_zip function for NC31

### DIFF
--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -301,7 +301,7 @@ class NcSessionBasic(NcSessionBase, ABC):
 
     def download2fp(self, url_path: str, fp, dav: bool, params=None, **kwargs):
         adapter = self.adapter_dav if dav else self.adapter
-        with adapter.stream("GET", url_path, params=params) as response:
+        with adapter.stream("GET", url_path, params=params, headers=kwargs.get("headers", None)) as response:
             check_error(response)
             for data_chunk in response.iter_raw(chunk_size=kwargs.get("chunk_size", 5 * 1024 * 1024)):
                 fp.write(data_chunk)
@@ -425,7 +425,7 @@ class AsyncNcSessionBasic(NcSessionBase, ABC):
 
     async def download2fp(self, url_path: str, fp, dav: bool, params=None, **kwargs):
         adapter = self.adapter_dav if dav else self.adapter
-        async with adapter.stream("GET", url_path, params=params) as response:
+        async with adapter.stream("GET", url_path, params=params, headers=kwargs.get("headers", None)) as response:
             check_error(response)
             async for data_chunk in response.aiter_raw(chunk_size=kwargs.get("chunk_size", 5 * 1024 * 1024)):
                 fp.write(data_chunk)

--- a/nc_py_api/files/files_async.py
+++ b/nc_py_api/files/files_async.py
@@ -119,9 +119,14 @@ class AsyncFilesAPI:
         path = path.user_path if isinstance(path, FsNode) else path
         result_path = local_path if local_path else os.path.basename(path)
         with open(result_path, "wb") as fp:
-            await self._session.download2fp(
-                "/index.php/apps/files/ajax/download.php", fp, dav=False, params={"dir": path}, **kwargs
-            )
+            if (await self._session.nc_version)["major"] >= 31:
+                full_path = dav_get_obj_path(await self._session.user, path)
+                accept_header = f"application/{kwargs.get('format', 'zip')}"
+                await self._session.download2fp(quote(full_path), fp, dav=True, headers={"Accept": accept_header})
+            else:
+                await self._session.download2fp(
+                    "/index.php/apps/files/ajax/download.php", fp, dav=False, params={"dir": path}, **kwargs
+                )
         return Path(result_path)
 
     async def upload(self, path: str | FsNode, content: bytes | str) -> FsNode:


### PR DESCRIPTION
In 31 Nextcloud, the old method of downloading folders has simply been removed.

The changes are very useful, downloading a folder through webdav has become more pleasant, and now we can download it in `tar` format, something like this:

```python
   nc.files.download_directory_as_zip("test_empty_dir_in_dir", "2.tar", format="x-tar")
```

Default usage doesn't changed, so **no something breaking** for nc_py_api usage.

References: 
* https://github.com/nextcloud/documentation/pull/12247
* https://github.com/nextcloud/server/pull/48098