### PR TITLE
Use system trust store by default

### DIFF
--- a/nc_py_api/_version.py
+++ b/nc_py_api/_version.py
@@ -1,3 +1,3 @@
 """Version of nc_py_api."""
 
-__version__ = "0.18.1"
+__version__ = "0.18.2"

--- a/nc_py_api/options.py
+++ b/nc_py_api/options.py
@@ -45,6 +45,7 @@ else:
     # Use system certificate stores
 
     import ssl
+
     import truststore
 
     NPA_NC_CERT = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)

--- a/nc_py_api/options.py
+++ b/nc_py_api/options.py
@@ -33,11 +33,21 @@ NPA_NC_CERT: bool | str
 SSL certificates (a.k.a CA bundle) used to  verify the identity of requested hosts. Either **True** (default CA bundle),
 a path to an SSL certificate file, or **False** (which will disable verification)."""
 str_val = environ.get("NPA_NC_CERT", "True")
-NPA_NC_CERT = True
+# https://github.com/encode/httpx/issues/302
+# when "httpx" will switch to use "truststore" by default - uncomment next line
+# NPA_NC_CERT = True
 if str_val.lower() in ("false", "0"):
     NPA_NC_CERT = False
 elif str_val.lower() not in ("true", "1"):
     NPA_NC_CERT = str_val
+else:
+    # Temporary workaround, see comment above.
+    # Use system certificate stores
+
+    import ssl
+    import truststore
+
+    NPA_NC_CERT = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
 CHUNKED_UPLOAD_V2 = environ.get("CHUNKED_UPLOAD_V2", True)
 """Option to enable/disable **version 2** chunked upload(better Object Storages support).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
   "pydantic>=2.1.1",
   "python-dotenv>=1",
   "xmltodict>=0.13",
+  "truststore==0.10.0",
 ]
 optional-dependencies.app = [
   "uvicorn[standard]>=0.23.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = [
   "httpx>=0.25.2",
   "pydantic>=2.1.1",
   "python-dotenv>=1",
+  "truststore==0.10",
   "xmltodict>=0.13",
-  "truststore==0.10.0",
 ]
 optional-dependencies.app = [
   "uvicorn[standard]>=0.23.2",


### PR DESCRIPTION
After internal discussion with @kyteinsky when we tested this https://github.com/nextcloud/app_api/pull/448 - it was found out that the `test-deploy` ExApp from AppAPI "Test Deploy" button action fails in such setups, since the Python library "httpx" ignores system certificates by default.

reference: https://github.com/encode/httpx/issues/302

Temporary workaround, until "httpx" will change it's behavior.