### PR TITLE
ExApps should not require `AA-VERSION` header

### DIFF
--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -478,7 +478,6 @@ class NcSessionAppBasic(ABC):
 
     def sign_check(self, request: HTTPConnection) -> str:
         headers = {
-            "AA-VERSION": request.headers.get("AA-VERSION", ""),
             "EX-APP-ID": request.headers.get("EX-APP-ID", ""),
             "EX-APP-VERSION": request.headers.get("EX-APP-VERSION", ""),
             "AUTHORIZATION-APP-API": request.headers.get("AUTHORIZATION-APP-API", ""),


### PR DESCRIPTION
Reason: AppAPI are already a bundled app, that distributes with Nextcloud Server and always have a version that Nextcloud Server have and this header is not needed anymore.


Starting from **Nextcloud 32** AppAPI will stop sending this header to the ExApps.

We do not drop sending `AA-VERSION` header to the NC, until we drop the support of NC31, as old AppAPI versions still require those header, we just removing this header from the required header list.