### PR TITLE
enabled AppAPIAuthMiddleware for websockets(Nextcloud 32+)

### DIFF
--- a/nc_py_api/ex_app/integration_fastapi.py
+++ b/nc_py_api/ex_app/integration_fastapi.py
@@ -241,7 +241,7 @@ class AppAPIAuthMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Method that will be called by Starlette for each event."""
-        if scope["type"] != "http":
+        if scope["type"] not in ("http", "websocket"):
             await self.app(scope, receive, send)
             return
 


### PR DESCRIPTION
ExApps starting with Nextсloud 32 are planned to have **websockets** support - we enable authentication in advance, so that there is time to rebuild ExApps.