### PR TITLE
fix: Handle JSON responses

### DIFF
--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -197,6 +197,7 @@ class NcSessionBasic(NcSessionBase, ABC):
         *,
         content: bytes | str | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
         json: dict | list | None = None,
+        response_type: str | None = None,
         params: dict | None = None,
         files: dict | None = None,
         **kwargs,
@@ -215,6 +216,8 @@ class NcSessionBasic(NcSessionBase, ABC):
         if response.status_code == 204:  # NO_CONTENT
             return []
         response_data = loads(response.text)
+        if response_type == "json":
+            return response_data
         ocs_meta = response_data["ocs"]["meta"]
         if ocs_meta["status"] != "ok":
             if (
@@ -319,6 +322,7 @@ class AsyncNcSessionBasic(NcSessionBase, ABC):
         *,
         content: bytes | str | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
         json: dict | list | None = None,
+        response_type: str | None = None,
         params: dict | None = None,
         files: dict | None = None,
         **kwargs,
@@ -337,6 +341,8 @@ class AsyncNcSessionBasic(NcSessionBase, ABC):
         if response.status_code == 204:  # NO_CONTENT
             return []
         response_data = loads(response.text)
+        if response_type == "json":
+            return response_data
         ocs_meta = response_data["ocs"]["meta"]
         if ocs_meta["status"] != "ok":
             if (

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -137,11 +137,14 @@ class _NextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         *,
         content: bytes | str | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
         json: dict | list | None = None,
+        response_type: str | None = None,
         params: dict | None = None,
         **kwargs,
     ):
         """Performs OCS call and returns OCS response payload data."""
-        return self._session.ocs(method, path, content=content, json=json, params=params, **kwargs)
+        return self._session.ocs(
+            method, path, content=content, json=json, response_type=response_type, params=params, **kwargs
+        )
 
     def download_log(self, fp) -> None:
         """Downloads Nextcloud log file. Requires Admin privileges."""
@@ -238,11 +241,14 @@ class _AsyncNextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         *,
         content: bytes | str | typing.Iterable[bytes] | typing.AsyncIterable[bytes] | None = None,
         json: dict | list | None = None,
+        response_type: str | None = None,
         params: dict | None = None,
         **kwargs,
     ):
         """Performs OCS call and returns OCS response payload data."""
-        return await self._session.ocs(method, path, content=content, json=json, params=params, **kwargs)
+        return await self._session.ocs(
+            method, path, content=content, json=json, response_type=response_type, params=params, **kwargs
+            )
 
     async def download_log(self, fp) -> None:
         """Downloads Nextcloud log file. Requires Admin privileges."""

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -248,7 +248,7 @@ class _AsyncNextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         """Performs OCS call and returns OCS response payload data."""
         return await self._session.ocs(
             method, path, content=content, json=json, response_type=response_type, params=params, **kwargs
-            )
+        )
 
     async def download_log(self, fp) -> None:
         """Downloads Nextcloud log file. Requires Admin privileges."""


### PR DESCRIPTION
Sends the response text immediately if the response type is set to `json`
Made for dealing with a JSONResponse that does not include an OCS object