### PR TITLE
fix: support for compressed content in download2stream method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.3 - 2025-04-28]
+
+### Fixed
+
+- Method `download2stream` not working correctly when Nextcloud returns compressed content. #352 Thanks to @PatrickPromitzer for reporting this.
+
 ## [0.19.2 - 2025-03-17]
 
 ### Added

--- a/nc_py_api/_session.py
+++ b/nc_py_api/_session.py
@@ -307,7 +307,7 @@ class NcSessionBasic(NcSessionBase, ABC):
         adapter = self.adapter_dav if dav else self.adapter
         with adapter.stream("GET", url_path, params=params, headers=kwargs.get("headers")) as response:
             check_error(response)
-            for data_chunk in response.iter_raw(chunk_size=kwargs.get("chunk_size", 5 * 1024 * 1024)):
+            for data_chunk in response.iter_bytes(chunk_size=kwargs.get("chunk_size", 5 * 1024 * 1024)):
                 fp.write(data_chunk)
 
 
@@ -434,7 +434,7 @@ class AsyncNcSessionBasic(NcSessionBase, ABC):
         adapter = self.adapter_dav if dav else self.adapter
         async with adapter.stream("GET", url_path, params=params, headers=kwargs.get("headers")) as response:
             check_error(response)
-            async for data_chunk in response.aiter_raw(chunk_size=kwargs.get("chunk_size", 5 * 1024 * 1024)):
+            async for data_chunk in response.aiter_bytes(chunk_size=kwargs.get("chunk_size", 5 * 1024 * 1024)):
                 fp.write(data_chunk)
 
 


### PR DESCRIPTION
Fixes #352 .

By switching from `iter_raw` to `iter_bytes`, **httpx will automatically handle the decompression** if the `Content-Encoding: gzip` header is present. If the header is absent or specifies no compression (like identity), `iter_bytes` will yield the original bytes, just like `iter_raw` would have.