### PR TITLE
feat: convert datetime values to RFC 3339 in WebDAV search literals

### DIFF
--- a/tests/actual_tests/files_test.py
+++ b/tests/actual_tests/files_test.py
@@ -2,7 +2,7 @@ import contextlib
 import math
 import os
 import zipfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from random import choice, randbytes
@@ -751,6 +751,15 @@ def test_find_files_listdir_depth(nc_any):
     assert not nc_any.files.find(["like", "name", "no%such%file"], path="test_dir")
     result = nc_any.files.find(["like", "mime", "text/%"], path="test_dir")
     assert len(result) == 4
+
+
+def test_find_files_datetime(nc_any):
+    time_in_past = datetime.now() - timedelta(days=1)
+    time_in_future = datetime.now() + timedelta(days=1)
+    assert len(nc_any.files.find(["gt", "last_modified", time_in_past], "/test_dir/subdir/"))
+    assert not len(nc_any.files.find(["gt", "last_modified", time_in_future], "/test_dir/subdir/"))
+    assert not len(nc_any.files.find(["lt", "last_modified", time_in_past], "/test_dir/subdir/"))
+    assert len(nc_any.files.find(["lt", "last_modified", time_in_future], "/test_dir/subdir/"))
 
 
 def test_listdir_depth(nc_any):


### PR DESCRIPTION
Fixes #347 .

This PR fixes incorrect handling of `datetime` and `date` objects in WebDAV `find()` queries. Previously, passing a `datetime` resulted in an invalid string format like `2025-03-10 12:34:56.123456`, causing Nextcloud to misinterpret the value in `<d:literal>`.

**Changes made:**
- Added `_dav_literal()` helper to format datetime values as RFC 3339 strings (`2025-03-10T12:34:56Z`)
- Updated `build_search_req()` to use this helper when generating `<d:literal>` values

This ensures proper comparison logic for operators like `"gt"` and `"lt"` when filtering by `last_modified` or other time-based properties.

Fixes issues where files were incorrectly included or excluded due to string-based comparison.