### PR TITLE
feat(http): switch httpx for niquests in order to stabilize network I/O

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ nitpick_ignore_regex = [
     (r"py:class", r"ComputedFieldInfo"),
     (r"py:class", r"FieldInfo"),
     (r"py:class", r"ConfigDict"),
-    (r"py:.*", r"httpx.*"),
+    (r"py:.*", r"niquests.*"),
 ]
 
 autodoc_member_order = "bysource"

--- a/examples/as_app/talk_bot/lib/main.py
+++ b/examples/as_app/talk_bot/lib/main.py
@@ -4,7 +4,7 @@ import re
 from contextlib import asynccontextmanager
 from typing import Annotated
 
-import httpx
+import niquests
 from fastapi import BackgroundTasks, Depends, FastAPI, Response
 
 from nc_py_api import NextcloudApp, talk_bot
@@ -32,7 +32,7 @@ def convert_currency(amount, from_currency, to_currency):
     base_url = "https://api.exchangerate-api.com/v4/latest/"
 
     # Fetch latest exchange rates
-    response = httpx.get(base_url + from_currency, timeout=60)
+    response = niquests.get(base_url + from_currency, timeout=60)
     data = response.json()
 
     if "rates" in data:

--- a/nc_py_api/_exceptions.py
+++ b/nc_py_api/_exceptions.py
@@ -1,6 +1,6 @@
 """Exceptions for the Nextcloud API."""
 
-from httpx import Response, codes
+from niquests import HTTPError, Response
 
 
 class NextcloudException(Exception):
@@ -60,6 +60,8 @@ def check_error(response: Response, info: str = ""):
         else:
             phrase = "Unknown error"
         raise NextcloudException(status_code, reason=phrase, info=info)
-    if not codes.is_error(status_code):
-        return
-    raise NextcloudException(status_code, reason=codes(status_code).phrase, info=info)
+
+    try:
+        response.raise_for_status()
+    except HTTPError as e:
+        raise NextcloudException(status_code, reason=response.reason, info=info) from e

--- a/nc_py_api/calendar_api.py
+++ b/nc_py_api/calendar_api.py
@@ -23,7 +23,7 @@ try:
             if body:
                 body = body.replace(b"\n", b"\r\n").replace(b"\r\r\n", b"\r\n")
             r = self._session.adapter_dav.request(
-                method, url if isinstance(url, str) else str(url), content=body, headers=headers
+                method, url if isinstance(url, str) else str(url), data=body, headers=headers
             )
             return DAVResponse(r)
 

--- a/nc_py_api/files/_files.py
+++ b/nc_py_api/files/_files.py
@@ -9,7 +9,7 @@ from urllib.parse import unquote
 from xml.etree import ElementTree
 
 import xmltodict
-from httpx import Response
+from niquests import Response
 
 from .._exceptions import NextcloudException, check_error
 from .._misc import check_capabilities, clear_from_params_empty

--- a/nc_py_api/loginflow_v2.py
+++ b/nc_py_api/loginflow_v2.py
@@ -5,7 +5,7 @@ import json
 import time
 from dataclasses import dataclass
 
-import httpx
+import niquests
 
 from ._exceptions import check_error
 from ._session import AsyncNcSession, NcSession
@@ -156,6 +156,6 @@ class _AsyncLoginFlowV2API:
         return r_model
 
 
-def _res_to_json(response: httpx.Response) -> dict:
+def _res_to_json(response: niquests.Response) -> dict:
     check_error(response)
     return json.loads(response.text)

--- a/nc_py_api/nextcloud.py
+++ b/nc_py_api/nextcloud.py
@@ -4,7 +4,7 @@ import contextlib
 import typing
 from abc import ABC
 
-from httpx import Headers
+from niquests.structures import CaseInsensitiveDict
 
 from ._exceptions import NextcloudExceptionNotFound
 from ._misc import check_capabilities, require_capabilities
@@ -112,8 +112,8 @@ class _NextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         self._session.update_server_info()
 
     @property
-    def response_headers(self) -> Headers:
-        """Returns the `HTTPX headers <https://www.python-httpx.org/api/#headers>`_ from the last response."""
+    def response_headers(self) -> CaseInsensitiveDict:
+        """Returns the `Niquests headers <https://www.python-httpx.org/api/#headers>`_ from the last response."""
         return self._session.response_headers
 
     @property
@@ -216,8 +216,8 @@ class _AsyncNextcloudBasic(ABC):  # pylint: disable=too-many-instance-attributes
         await self._session.update_server_info()
 
     @property
-    def response_headers(self) -> Headers:
-        """Returns the `HTTPX headers <https://www.python-httpx.org/api/#headers>`_ from the last response."""
+    def response_headers(self) -> CaseInsensitiveDict:
+        """Returns the `Niquests headers <https://www.python-httpx.org/api/#headers>`_ from the last response."""
         return self._session.response_headers
 
     @property

--- a/nc_py_api/notes.py
+++ b/nc_py_api/notes.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import typing
 
-import httpx
+import niquests
 
 from ._exceptions import check_error
 from ._misc import check_capabilities, clear_from_params_empty, require_capabilities
@@ -367,6 +367,6 @@ class _AsyncNotesAPI:
         check_error(await self._session.adapter.put(self._ep_base + "/settings", json=params))
 
 
-def _res_to_json(response: httpx.Response) -> dict:
+def _res_to_json(response: niquests.Response) -> dict:
     check_error(response)
     return json.loads(response.text) if response.status_code != 304 else {}

--- a/nc_py_api/options.py
+++ b/nc_py_api/options.py
@@ -33,22 +33,13 @@ NPA_NC_CERT: bool | str
 SSL certificates (a.k.a CA bundle) used to  verify the identity of requested hosts. Either **True** (default CA bundle),
 a path to an SSL certificate file, or **False** (which will disable verification)."""
 str_val = environ.get("NPA_NC_CERT", "True")
-# https://github.com/encode/httpx/issues/302
-# when "httpx" will switch to use "truststore" by default - uncomment next line
-# NPA_NC_CERT = True
+
+NPA_NC_CERT = True
+
 if str_val.lower() in ("false", "0"):
     NPA_NC_CERT = False
 elif str_val.lower() not in ("true", "1"):
     NPA_NC_CERT = str_val
-else:
-    # Temporary workaround, see comment above.
-    # Use system certificate stores
-
-    import ssl
-
-    import truststore
-
-    NPA_NC_CERT = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
 CHUNKED_UPLOAD_V2 = environ.get("CHUNKED_UPLOAD_V2", True)
 """Option to enable/disable **version 2** chunked upload(better Object Storages support).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,9 @@ dynamic = [
 ]
 dependencies = [
   "fastapi>=0.109.2",
-  "httpx>=0.25.2",
+  "niquests>=3,<4",
   "pydantic>=2.1.1",
   "python-dotenv>=1",
-  "truststore==0.10",
   "xmltodict>=0.13",
 ]
 optional-dependencies.app = [

--- a/tests/_app_security_checks.py
+++ b/tests/_app_security_checks.py
@@ -2,19 +2,19 @@ from base64 import b64encode
 from os import environ
 from sys import argv
 
-import httpx
+import niquests
 
 
 def sign_request(req_headers: dict, secret=None, user: str = ""):
     app_secret = secret if secret is not None else environ["APP_SECRET"]
-    req_headers["AUTHORIZATION-APP-API"] = b64encode(f"{user}:{app_secret}".encode("UTF=8"))
+    req_headers["AUTHORIZATION-APP-API"] = b64encode(f"{user}:{app_secret}".encode("utf-8"))
 
 
 # params: app base url
 if __name__ == "__main__":
     request_url = argv[1] + "/sec_check?value=1"
     headers = {}
-    result = httpx.put(request_url, headers=headers)
+    result = niquests.put(request_url, headers=headers)
     assert result.status_code == 401  # Missing headers
     headers.update(
         {
@@ -24,22 +24,22 @@ if __name__ == "__main__":
         }
     )
     sign_request(headers)
-    result = httpx.put(request_url, headers=headers)
+    result = niquests.put(request_url, headers=headers)
     assert result.status_code == 200
     # Invalid AA-SIGNATURE
     sign_request(headers, secret="xxx")
-    result = httpx.put(request_url, headers=headers)
+    result = niquests.put(request_url, headers=headers)
     assert result.status_code == 401
     sign_request(headers)
-    result = httpx.put(request_url, headers=headers)
+    result = niquests.put(request_url, headers=headers)
     assert result.status_code == 200
     # Invalid EX-APP-ID
     old_app_name = headers.get("EX-APP-ID")
     headers["EX-APP-ID"] = "unknown_app"
     sign_request(headers)
-    result = httpx.put(request_url, headers=headers)
+    result = niquests.put(request_url, headers=headers)
     assert result.status_code == 401
     headers["EX-APP-ID"] = old_app_name
     sign_request(headers)
-    result = httpx.put(request_url, headers=headers)
+    result = niquests.put(request_url, headers=headers)
     assert result.status_code == 200

--- a/tests/_install_wait.py
+++ b/tests/_install_wait.py
@@ -2,7 +2,7 @@ import re
 from sys import argv
 from time import sleep
 
-from requests import get
+from niquests import get
 
 
 def check_heartbeat(url: str, regexp: str, n_tries: int, wait_interval: float) -> int:

--- a/tests/actual_tests/logs_test.py
+++ b/tests/actual_tests/logs_test.py
@@ -128,9 +128,9 @@ def test_logging(nc_app):
 
 
 def test_recursive_logging(nc_app):
-    logging.getLogger("httpx").setLevel(logging.DEBUG)
+    logging.getLogger("niquests").setLevel(logging.DEBUG)
     log_handler = setup_nextcloud_logging()
     logger = logging.getLogger()
     logger.fatal("testing logging.fatal")
     logger.removeHandler(log_handler)
-    logging.getLogger("httpx").setLevel(logging.ERROR)
+    logging.getLogger("niquests").setLevel(logging.ERROR)

--- a/tests/actual_tests/misc_test.py
+++ b/tests/actual_tests/misc_test.py
@@ -3,7 +3,7 @@ import io
 import os
 
 import pytest
-from httpx import Request, Response
+from niquests import PreparedRequest, Response
 
 from nc_py_api import (
     AsyncNextcloud,
@@ -21,11 +21,18 @@ from nc_py_api._session import BasicConfig  # noqa
 
 @pytest.mark.parametrize("code", (995, 996, 997, 998, 999, 1000))
 def test_check_error(code):
+    resp = Response()
+
+    resp.status_code = code
+    resp.request = PreparedRequest()
+    resp.request.url = "https://example"
+    resp.request.method = "GET"
+
     if 996 <= code <= 999:
         with pytest.raises(NextcloudException):
-            check_error(Response(code, request=Request(method="GET", url="https://example")))
+            check_error(resp)
     else:
-        check_error(Response(code, request=Request(method="GET", url="https://example")))
+        check_error(resp)
 
 
 def test_nc_exception_to_str():

--- a/tests/actual_tests/talk_bot_test.py
+++ b/tests/actual_tests/talk_bot_test.py
@@ -1,6 +1,6 @@
 from os import environ
 
-import httpx
+import niquests
 import pytest
 
 from nc_py_api import talk, talk_bot
@@ -88,7 +88,7 @@ async def test_list_bots_async(anc, anc_app):
 def test_chat_bot_receive_message(nc_app):
     if nc_app.talk.bots_available is False:
         pytest.skip("Need Talk bots support")
-    httpx.delete(f"{'http'}://{environ.get('APP_HOST', '127.0.0.1')}:{environ['APP_PORT']}/reset_bot_secret")
+    niquests.delete(f"{'http'}://{environ.get('APP_HOST', '127.0.0.1')}:{environ['APP_PORT']}/reset_bot_secret")
     talk_bot_inst = talk_bot.TalkBot("/talk_bot_coverage", "Coverage bot", "Desc")
     talk_bot_inst.enabled_handler(True, nc_app)
     conversation = nc_app.talk.create_conversation(talk.ConversationType.GROUP, "admin")
@@ -136,7 +136,7 @@ def test_chat_bot_receive_message(nc_app):
 async def test_chat_bot_receive_message_async(anc_app):
     if await anc_app.talk.bots_available is False:
         pytest.skip("Need Talk bots support")
-    httpx.delete(f"{'http'}://{environ.get('APP_HOST', '127.0.0.1')}:{environ['APP_PORT']}/reset_bot_secret")
+    niquests.delete(f"{'http'}://{environ.get('APP_HOST', '127.0.0.1')}:{environ['APP_PORT']}/reset_bot_secret")
     talk_bot_inst = talk_bot.AsyncTalkBot("/talk_bot_coverage", "Coverage bot", "Desc")
     await talk_bot_inst.enabled_handler(True, anc_app)
     conversation = await anc_app.talk.create_conversation(talk.ConversationType.GROUP, "admin")


### PR DESCRIPTION
Fixes #365 

Changes proposed in this pull request:

 * Move from httpx to niquests.

Quick history around that, httpx is being a bit stale for a couple of years now and report of spurious errors like the one in #365 is killing the global UX of that library. Not only that but httpx is absolutely unusable in the freethreaded build for example, it crash instantly on any attempt. Moreover the performance are often pointed out, especially in async. While Niquests isn't faster than aiohttp right now, it's better than requests and httpx.

Finally, a touch of hope, we recently were selected into the [GitHub Secure Open Source Program](https://github.blog/open-source/maintainers/securing-the-supply-chain-at-scale-starting-with-71-important-open-source-projects/#developer-utilities-and-cli-helpers-%f0%9f%a7%91%f0%9f%92%bb) (Session 2)! We manage several packages and one very high profile (charset-normalizer). Our security standards are solid and we currently are in the way of making every (of our own) package CRA compliant (charset-normalizer already is!).
 
This PR is a firm start into migrating from httpx, I will take the time to add comments using GitHub UI so that you can quickly understand why a change occurred this and there. I tried my best to keep the change surface as minimal as I could.

Before submitting this, I ensured that the tests were all good.

<img width="643" height="634" alt="image" src="https://github.com/user-attachments/assets/d17b8a75-cb3e-403c-b1eb-a403d5e2209f" />


Regards,
