### PR TITLE
feat(TaskProcessing): Add trigger_handler to set_handlers()

### DIFF
--- a/nc_py_api/ex_app/integration_fastapi.py
+++ b/nc_py_api/ex_app/integration_fastapi.py
@@ -132,14 +132,14 @@ def set_handlers(
         if asyncio.iscoroutinefunction(trigger_handler):
 
             @fast_api_app.post("/trigger")
-            async def trigger_callback(providerId: str):# pylint: disable=invalid-name
+            async def trigger_callback(providerId: str):  # pylint: disable=invalid-name
                 await trigger_handler(providerId)
                 return JSONResponse(content={})
 
         else:
 
             @fast_api_app.post("/trigger")
-            def trigger_callback(providerId: str):# pylint: disable=invalid-name
+            def trigger_callback(providerId: str):  # pylint: disable=invalid-name
                 trigger_handler(providerId)
                 return JSONResponse(content={})
 


### PR DESCRIPTION
See https://github.com/nextcloud/app_api/pull/683 for the corresponding AppAPI PR.

Changes proposed in this pull request:

 * Add a `trigger_handler` param to set_handlers() that will be called when the /trigger endpoint is requested by AppAPI.
