### PR TITLE
feat(TaskProcessing): Add next_task_batch endpoint

### DIFF
--- a/nc_py_api/ex_app/providers/task_processing.py
+++ b/nc_py_api/ex_app/providers/task_processing.py
@@ -145,8 +145,8 @@ class _TaskProcessingProviderAPI:
     def next_task_batch(
         self, provider_ids: list[str], task_types: list[str], number_of_tasks: int
     ) -> dict[str, typing.Any]:
-        """
-        Get the next n task processing tasks from Nextcloud.
+        """Get the next n task processing tasks from Nextcloud.
+
         Available starting with Nextcloud 33
         Returns: {tasks: [{task: Task, provider: string}], has_more: bool}
         """
@@ -240,8 +240,8 @@ class _AsyncTaskProcessingProviderAPI:
     async def next_task_batch(
         self, provider_ids: list[str], task_types: list[str], number_of_tasks: int
     ) -> dict[str, typing.Any]:
-        """
-        Get the next n task processing tasks from Nextcloud.
+        """Get the next n task processing tasks from Nextcloud.
+
         Available starting with Nextcloud 33
         Returns: {tasks: [{task: Task, provider: string}], has_more: bool}
         """


### PR DESCRIPTION
Changes proposed in this pull request:

 * Adds a method for the [next_batch taskprocessing OCS endpoint](https://docs.nextcloud.com/server/latest/developer_manual/_static/openapi.html#/operations/core-task_processing_api-get-next-scheduled-task-batch)


Untested.