### PR TITLE
fix: handle bot join messages properly to get conversation id and name

### DIFF
--- a/nc_py_api/talk_bot.py
+++ b/nc_py_api/talk_bot.py
@@ -76,11 +76,17 @@ class TalkBotMessage:
 
         It can be used to react or reply to the given message.
         """
+        # bot join
+        if self.message_type == "Join":
+            return self._raw_data["object"]["id"]
         return self._raw_data["target"]["id"]
 
     @property
     def conversation_name(self) -> str:
         """The name of the conversation in which the message was posted."""
+        # bot join
+        if self.message_type == "Join":
+            return self._raw_data["object"]["name"]
         return self._raw_data["target"]["name"]
 
     def __repr__(self):


### PR DESCRIPTION
Changes proposed in this pull request:

 * handle bot join messages properly to get conversation id and name

bot join message:
```py
{'type': 'Join', 'actor': {'type': 'Application', 'id': 'bots/bot-8fbab44b3648e53e2252d262ab600532a4232ee8', 'name': 'SummaryBot'}, 'object': {'type': 'Collection', 'id': 'x8w9eukg', 'name': 'summary test'}, '_route': 'ocs.app_api.talkbot.proxytalkmessage', 'appId': 'summary_bot', 'route': 'summary_bot'}
```

user join message:
```py
{'type': 'Activity', 'actor': {'type': 'Person', 'id': 'users/bob', 'name': 'bob'}, 'object': {'type': 'Note', 'id': '401', 'name': 'user_added', 'content': '{"message":"{actor} joined the conversation","parameters":{"actor":{"type":"user","id":"bob","name":"bob","mention-id":"bob"},"user":{"type":"user","id":"bob","name":"bob","mention-id":"bob"}}}', 'mediaType': 'text/markdown'}, 'target': {'type': 'Collection', 'id': 'x8w9eukg', 'name': 'summary test'}, '_route': 'ocs.app_api.talkbot.proxytalkmessage', 'appId': 'summary_bot', 'route': 'summary_bot'}
```