### PR TITLE
fix(talk_bot): remove the dead appconfig_ex bot-secret fallback

### DIFF
--- a/nc_py_api/talk_bot.py
+++ b/nc_py_api/talk_bot.py
@@ -357,24 +357,16 @@ def __get_bot_secret(callback_url: str) -> str:
 
 
 def get_bot_secret(callback_url: str) -> bytes | None:
-    """Returns the bot's secret from an environment variable or from the application's configuration on the server."""
+    """Returns the bot's secret from the environment variable populated when the bot was registered."""
     secret_key = __get_bot_secret(callback_url)
     if secret_key in os.environ:
         return os.environ[secret_key].encode("UTF-8")
-    secret_value = NextcloudApp().appconfig_ex.get_value(secret_key)
-    if secret_value is not None:
-        os.environ[secret_key] = secret_value
-        return secret_value.encode("UTF-8")
     return None
 
 
 async def aget_bot_secret(callback_url: str) -> bytes | None:
-    """Returns the bot's secret from an environment variable or from the application's configuration on the server."""
+    """Returns the bot's secret from the environment variable populated when the bot was registered."""
     secret_key = __get_bot_secret(callback_url)
     if secret_key in os.environ:
         return os.environ[secret_key].encode("UTF-8")
-    secret_value = await AsyncNextcloudApp().appconfig_ex.get_value(secret_key)
-    if secret_value is not None:
-        os.environ[secret_key] = secret_value
-        return secret_value.encode("UTF-8")
     return None


### PR DESCRIPTION
> ⚠️ **This pull request was generated by an AI coding agent and opened automatically.** It was not manually authored or human-reviewed before opening — please review carefully before merging.

`get_bot_secret()` / `aget_bot_secret()` resolve a Talk bot's secret in two steps: first from the environment variable `os.environ[sha1(APP_ID + "_" + callback_url)]`, and — if that is missing — by reading it from server-side app config via `NextcloudApp().appconfig_ex.get_value(secret_key)`.

That second step is dead code. AppAPI's TalkBot rework (nextcloud/app_api#866) moved bot secrets into a dedicated `ex_apps_talk_bots` table and removed them from `appconfig_ex`, so a bot-secret lookup against the config store can never find anything — it always returns `None`.

It is also unnecessary, not merely dead. `register_talk_bot()` returns the secret on every call (AppAPI returns the existing secret for an already-registered bot, not only when minting a new one), and nc_py_api caches it into `os.environ[bot_id]` right after registering. ExApps re-register their bots on enable/startup, so the environment variable is always (re)populated — and that is what actually serves the secret in `get_bot_secret()`. The existing `reset_bot_secret` test flow confirms this: it pops the env var, then `enabled_handler(True)` re-registers and repopulates it.

This removes the fallback from both functions. It is behavior-preserving (the fallback returns `None` today regardless), removes a pointless OCS round-trip on the rare env-miss path, and drops the last stale `appconfig_ex` reference in the Talk path.

Surfaced while reviewing the AppAPI config-storage migration (`appconfig_ex` / `preferences_ex` → `IAppConfig` / `IUserConfig`); this is the nc_py_api-side follow-up to nextcloud/app_api#866.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Bot secret retrieval now exclusively uses environment variables, removing the previous server-side fallback mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-py-api/nc_py_api/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->