### PR TITLE
ci: keep Notes app compatible across the stable31/32/33 matrix

### DIFF
--- a/.github/workflows/analysis-coverage.yml
+++ b/.github/workflows/analysis-coverage.yml
@@ -203,7 +203,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: nextcloud/notes
-          ref: "main"
+          # Notes main (v5.0.0) requires NC >= 33; pin older servers to the last 4.x (supports NC 28-34).
+          ref: "${{ (matrix.nextcloud == 'stable31' || matrix.nextcloud == 'stable32') && 'v4.13.1' || 'main' }}"
           path: apps/notes
 
       - name: Checkout Files Locking
@@ -548,7 +549,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: nextcloud/notes
-          ref: "main"
+          # Notes main (v5.0.0) requires NC >= 33; pin older servers to the last 4.x (supports NC 28-34).
+          ref: "${{ (matrix.nextcloud == 'stable31' || matrix.nextcloud == 'stable32') && 'v4.13.1' || 'main' }}"
           path: apps/notes
 
       - name: Checkout Files Locking


### PR DESCRIPTION
The two `Checkout Notes` steps pin the Notes app to `ref: "main"`. Notes `main` is now `v5.0.0` with `min-version="33"`, so `occ app:enable notes` fails on the older servers and the `stable31` (Client) and `stable32` (Maria) jobs go red at the `Enable Notes` step. This has nothing to do with the changes of the PR it runs on, so right now it breaks CI on every open PR.

`nextcloud/notes` has no server matched stable branches, so the ref is now chosen by server version: `stable31` and `stable32` use the last `4.x` tag `v4.13.1` (supports NC 28 to 34), while `stable33` and newer keep `main` so the latest Notes stays under test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release contains no user-facing changes. The updates involve internal continuous integration workflow configurations to improve compatibility with different Nextcloud versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->