### PR TITLE
fix(deps): pin starlette>=1.0.1 to fix BadHost (CVE-2026-48710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.30.2 - 2026-06-02]
+
+### Changed
+
+- `download_directory_as_zip`: the order of entries inside the returned archive is no longer guaranteed; it now depends on the Nextcloud server's database backend, after Nextcloud server [#60225](https://github.com/nextcloud/server/pull/60225) removed the implicit `ORDER BY name ASC`. #429
+
+### Security
+
+- Pinned `starlette>=1.0.1` to address **BadHost** ([CVE-2026-48710](https://github.com/advisories/GHSA-86qp-5c8j-p5mr)): a crafted `Host` header could desync `request.url.path` from the routed path in Starlette ≤ 1.0.0, bypassing path-based authorization. FastAPI does not constrain Starlette's upper bound, so an explicit floor is required to guarantee the fix. The `fastapi` floor was also raised to `>=0.133` (the first release compatible with Starlette 1.0+).
+
 ## [0.30.1 - 2026-04-26]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,12 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "fastapi>=0.109.2",
+  "fastapi>=0.133",
   "filelock>=3.20.3,<4",
   "niquests>=3,<4",
   "pydantic>=2.1.1",
   "python-dotenv>=1",
+  "starlette>=1.0.1",
   "xmltodict>=0.13",
 ]
 optional-dependencies.app = [


### PR DESCRIPTION
## Summary

Remediates **BadHost** ([CVE-2026-48710](https://github.com/advisories/GHSA-86qp-5c8j-p5mr)), a Host-header path-confusion vulnerability in **Starlette ≤ 1.0.0** that can bypass path-based authorization. The fix lives in **Starlette 1.0.1**.

FastAPI does **not** cap Starlette (even latest `0.136.3` only requires `starlette>=0.46.0`), so bumping FastAPI alone does not guarantee a fixed Starlette, and an explicit floor is required. `nc_py_api` also imports `starlette` directly (`_session.py`, `ex_app/integration_fastapi.py`), so declaring it is correct regardless.

## Changes
- **`pyproject.toml`**
  - add `starlette>=1.0.1` (the BadHost fix)
  - raise `fastapi>=0.133` (the first FastAPI release compatible with Starlette 1.0+)
- **`CHANGELOG.md`**: `0.30.2` section:
  - `Security`: the BadHost pin
  - `Changed`: `download_directory_as_zip` archive entry order is no longer guaranteed (server-side, per nextcloud/server#60225)

The version bump (`_version.py` to `0.30.2`) is intentionally **omitted** here; it lands in the `[publish]` commit on `main` after merge.

## Compatibility
- Keeps Python `>=3.10` (FastAPI 0.133+ and Starlette 1.x both require `>=3.10`).
- Verified: under these constraints pip upgrades the vulnerable Starlette from `1.0.0` to `1.2.1`; `import nc_py_api` succeeds.
