### PR TITLE
fix(talk): Add NOTE_TO_SELF conversation type

### DIFF
--- a/nc_py_api/talk.py
+++ b/nc_py_api/talk.py
@@ -23,6 +23,8 @@ class ConversationType(enum.IntEnum):
     """Former "One to one"
     (When a user is deleted from the server or removed from all their conversations,
     "One to one" rooms are converted to this type)"""
+    NOTE_TO_SELF = 6
+    """Conversation for notes to self"""
 
 
 class ParticipantType(enum.IntEnum):


### PR DESCRIPTION
See https://github.com/nextcloud/spreed/blob/879c3bd573f98d835839fa210ce0a89231f513f1/lib/Room.php#L25-L31

Fixes talk tools in context_agent

Fixes https://github.com/cloud-py-api/nc_py_api/issues/440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "notes to self" conversation type in the Talk API, enabling users to create conversations designated for personal notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->