### PR TITLE
test(talk): fetch rooms once before checking modifiedSince

### DIFF
--- a/tests/actual_tests/talk_test.py
+++ b/tests/actual_tests/talk_test.py
@@ -85,6 +85,11 @@ def test_conversation_create_delete(nc):
 def test_get_conversations_modified_since(nc):
     if nc.talk.available is False:
         pytest.skip("Nextcloud Talk is not installed")
+    # Talk creates the "Note to self", sample and changelog conversations while serving a user's first
+    # rooms request, after it has captured the timestamp it reports in `X-Nextcloud-Talk-Modified-Before`.
+    # Those rooms are therefore newer than that timestamp; fetch once up front so that their creation
+    # cannot land inside the window checked below.
+    nc.talk.get_user_conversations()
     conversation = nc.talk.create_conversation(talk.ConversationType.GROUP, "admin")
     try:
         conversations = nc.talk.get_user_conversations()
@@ -102,6 +107,8 @@ def test_get_conversations_modified_since(nc):
 async def test_get_conversations_modified_since_async(anc):
     if await anc.talk.available is False:
         pytest.skip("Nextcloud Talk is not installed")
+    # see the comment in the sync test above
+    await anc.talk.get_user_conversations()
     conversation = await anc.talk.create_conversation(talk.ConversationType.GROUP, "admin")
     try:
         conversations = await anc.talk.get_user_conversations()


### PR DESCRIPTION
`test_get_conversations_modified_since` fails intermittently across the matrix (seen on #458 and earlier on `main`), always as `assert not [<Conversation name=Note to self>, <Conversation name=Let's get started!>]`.

Talk captures `X-Nextcloud-Talk-Modified-Before` (T) at the *start* of `getRooms` and only then dispatches `BeforeRoomsFetchEvent` ([RoomController.php:240-243](https://github.com/nextcloud/spreed/blob/main/lib/Controller/RoomController.php#L240)), whose listeners create the note-to-self, sample and changelog conversations the first time a user fetches rooms. Those rooms get a `lastActivity` newer than the T already reported, and the server filter is `lastActivity >= modifiedSince`. The test asks for `T + 2`, so it only passes while that creation finishes inside 2 seconds. Measured on an idle local server it already takes ~1.15 s.

Fetch the rooms once before the timed sequence so the lazy creation happens outside the checked window.

Reproduced end to end by making sample creation exceed the margin (Talk's `samples_directory`), then running the real test as a fresh admin user: current test fails, patched test passes, same server and conditions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation modification-date filtering tests by excluding pre-existing default rooms from results.
  * Synchronous and asynchronous conversation list behavior is now validated more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->