### PR TITLE
feat(files): request extra WebDAV properties and expose them on FsNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.30.4 - 2026-08-11]
 
+### Added
+
+- `extra_properties` argument for `listdir`, `by_path`, `by_id`, `find`, `list_by_criteria`, `trashbin_list` and `get_versions`, to request WebDAV properties the library does not model itself, e.g. `nc:has-preview`. The values are available in the new `FsNode.extra_properties`, which also exposes the properties that were requested by default but silently dropped until now, such as `oc:share-types` and `oc:checksums`. #453
+
 ### Fixed
 
 - ExApps: downloading a model from a direct link is retried when the host is throttling or temporarily failing (`408`, `425`, `429`, `500`, `502`, `503`, `504`) instead of failing the whole `init`. `Retry-After` is honoured up to a minute, otherwise the wait backs off exponentially. The number of extra attempts defaults to 5 and can be set per model with the new `max_retries` download option.

--- a/nc_py_api/files/__init__.py
+++ b/nc_py_api/files/__init__.py
@@ -6,6 +6,7 @@ import email.utils
 import enum
 import os
 import re
+import typing
 import warnings
 
 from pydantic import BaseModel
@@ -223,6 +224,15 @@ class FsNode:
     lock_info: FsNodeLockInfo
     """Class describing `lock` information if any."""
 
+    extra_properties: dict[str, typing.Any]
+    """WebDAV properties the server returned that :py:class:`FsNode` does not model itself, keyed by their
+    prefixed name, e.g. ``nc:has-preview``.
+
+    Values arrive as the server sent them: usually a ``str``, ``None`` when the property is empty, and a
+    ``dict``/``list`` for the nested ones such as ``oc:share-types``. Request additional properties with the
+    ``extra_properties`` argument of :py:meth:`~nc_py_api.files.files.FilesAPI.listdir` and friends.
+    """
+
     def __init__(self, full_path: str, **kwargs):
         self.full_path = full_path
         self.file_id = kwargs.get("file_id", "")
@@ -230,6 +240,7 @@ class FsNode:
         self.etag = kwargs.get("etag") or ""
         self.info = FsNodeInfo(**kwargs)
         self.lock_info = FsNodeLockInfo(**kwargs)
+        self.extra_properties = kwargs.get("extra_properties") or {}
 
     @property
     def is_dir(self) -> bool:

--- a/nc_py_api/files/_files.py
+++ b/nc_py_api/files/_files.py
@@ -68,10 +68,60 @@ class PropFindType(enum.IntEnum):
     VERSIONS_FILE_ID = 3
 
 
-def get_propfind_properties(capabilities: dict) -> list[str]:
+PROPFIND_NAMESPACES: typing.Final[tuple[str, ...]] = ("d", "oc", "nc")
+"""XML namespace prefixes declared in the requests, the only ones ``extra_properties`` can use."""
+
+MAPPED_PROPERTIES: typing.Final[frozenset[str]] = frozenset(
+    {
+        "d:creationdate",
+        "d:getcontentlength",
+        "d:getcontenttype",
+        "d:getetag",
+        "d:getlastmodified",
+        "nc:download-url-expiration",
+        "nc:lock",
+        "nc:lock-owner",
+        "nc:lock-owner-displayname",
+        "nc:lock-owner-editor",
+        "nc:lock-owner-type",
+        "nc:lock-time",
+        "nc:lock-timeout",
+        "nc:trashbin-deletion-time",
+        "nc:trashbin-filename",
+        "nc:trashbin-original-location",
+        "oc:downloadURL",
+        "oc:favorite",
+        "oc:fileid",
+        "oc:id",
+        "oc:permissions",
+        "oc:size",
+        "d:resourcetype",
+    }
+)
+"""Properties :py:class:`~nc_py_api.files.FsNode` models itself, the rest end up in ``extra_properties``."""
+
+
+def get_propfind_properties(capabilities: dict, extra_properties: Sequence[str] | None = None) -> list[str]:
     r = list(PROPFIND_PROPERTIES)
     if not check_capabilities("files.locking", capabilities):
         r += PROPFIND_LOCKING_PROPERTIES
+    return r + _validate_extra_properties(extra_properties, r)
+
+
+def _validate_extra_properties(extra_properties: Sequence[str] | None, already_requested: Sequence[str]) -> list[str]:
+    """Returns the additional properties to request, without the ones that are asked for anyway."""
+    if not extra_properties:
+        return []
+    r = []
+    for i in extra_properties:
+        prefix = i.split(":", maxsplit=1)[0] if ":" in i else ""
+        if prefix not in PROPFIND_NAMESPACES:
+            raise ValueError(
+                f"Invalid property `{i}`: expected one of the {', '.join(PROPFIND_NAMESPACES)} namespaces,"
+                f" e.g. `nc:has-preview`."
+            )
+        if i not in already_requested and i not in r:
+            r.append(i)
     return r
 
 
@@ -85,7 +135,9 @@ def _dav_literal(val: Any) -> str:
     return str(val)
 
 
-def build_find_request(req: list, path: str | FsNode, user: str, capabilities: dict) -> ElementTree.Element:
+def build_find_request(
+    req: list, path: str | FsNode, user: str, capabilities: dict, extra_properties: Sequence[str] | None = None
+) -> ElementTree.Element:
     path = path.user_path if isinstance(path, FsNode) else path
     root = ElementTree.Element(
         "d:searchrequest",
@@ -93,7 +145,7 @@ def build_find_request(req: list, path: str | FsNode, user: str, capabilities: d
     )
     xml_search = ElementTree.SubElement(root, "d:basicsearch")
     xml_select_prop = ElementTree.SubElement(ElementTree.SubElement(xml_search, "d:select"), "d:prop")
-    for i in get_propfind_properties(capabilities):
+    for i in get_propfind_properties(capabilities, extra_properties):
         ElementTree.SubElement(xml_select_prop, i)
     xml_from_scope = ElementTree.SubElement(ElementTree.SubElement(xml_search, "d:from"), "d:scope")
     href = f"/files/{user}/{path.removeprefix('/')}"
@@ -105,7 +157,10 @@ def build_find_request(req: list, path: str | FsNode, user: str, capabilities: d
 
 
 def build_list_by_criteria_req(
-    properties: list[str] | None, tags: list[int | SystemTag] | None, capabilities: dict
+    properties: list[str] | None,
+    tags: list[int | SystemTag] | None,
+    capabilities: dict,
+    extra_properties: Sequence[str] | None = None,
 ) -> ElementTree.Element:
     if not properties and not tags:
         raise ValueError("Either specify 'properties' or 'tags' to filter results.")
@@ -114,7 +169,7 @@ def build_list_by_criteria_req(
         attrib={"xmlns:d": "DAV:", "xmlns:oc": "http://owncloud.org/ns", "xmlns:nc": "http://nextcloud.org/ns"},
     )
     prop = ElementTree.SubElement(root, "d:prop")
-    for i in get_propfind_properties(capabilities):
+    for i in get_propfind_properties(capabilities, extra_properties):
         ElementTree.SubElement(prop, i)
     xml_filter_rules = ElementTree.SubElement(root, "oc:filter-rules")
     if properties and "favorite" in properties:
@@ -287,6 +342,7 @@ def etag_fileid_from_response(response: Response) -> dict:
 
 def _parse_record(full_path: str, prop_stats: list[dict]) -> FsNode:  # noqa pylint: disable = too-many-branches
     fs_node_args = {}
+    extra_properties: dict[str, typing.Any] = {}
     for prop_stat in prop_stats:
         if str(prop_stat.get("d:status", "")).find("200 OK") == -1:
             continue
@@ -336,7 +392,9 @@ def _parse_record(full_path: str, prop_stats: list[dict]) -> FsNode:  # noqa pyl
         }.items():
             if k in prop_keys and prop[k] is not None:
                 fs_node_args[v] = prop[k]
-    return FsNode(full_path, **fs_node_args)
+        # everything the server returned that FsNode does not model itself, values as the server sent them
+        extra_properties.update({k: v for k, v in prop.items() if k not in MAPPED_PROPERTIES and not k.startswith("@")})
+    return FsNode(full_path, extra_properties=extra_properties, **fs_node_args)
 
 
 def _parse_records(dav_url_suffix: str, fs_records: list[dict], response_type: PropFindType) -> list[FsNode]:

--- a/nc_py_api/files/files.py
+++ b/nc_py_api/files/files.py
@@ -80,7 +80,12 @@ class FilesAPI:
         return result[0] if result else None
 
     def by_path(self, path: str | FsNode, extra_properties: Sequence[str] | None = None) -> FsNode | None:
-        """Returns :py:class:`~nc_py_api.files.FsNode` by exact path if any."""
+        """Returns :py:class:`~nc_py_api.files.FsNode` by exact path if any.
+
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
+        """
         path = path.user_path if isinstance(path, FsNode) else path
         result = self.listdir(path, depth=0, exclude_self=False, extra_properties=extra_properties)
         return result[0] if result else None
@@ -311,8 +316,8 @@ class FilesAPI:
             "nc:trashbin-filename",
             "nc:trashbin-original-location",
             "nc:trashbin-deletion-time",
-            *_validate_extra_properties(extra_properties, PROPFIND_PROPERTIES),
         ]
+        properties += _validate_extra_properties(extra_properties, properties)
         return self._listdir(
             self._session.user, "", properties=properties, depth=1, exclude_self=False, prop_type=PropFindType.TRASHBIN
         )

--- a/nc_py_api/files/files.py
+++ b/nc_py_api/files/files.py
@@ -15,6 +15,7 @@ from . import FsNode, LockType, SystemTag
 from ._files import (
     PROPFIND_PROPERTIES,
     PropFindType,
+    _validate_extra_properties,
     build_find_request,
     build_list_by_criteria_req,
     build_list_tag_req,
@@ -43,43 +44,58 @@ class FilesAPI:
         self._session = session
         self.sharing = _FilesSharingAPI(session)
 
-    def listdir(self, path: str | FsNode = "", depth: int = 1, exclude_self=True) -> list[FsNode]:
+    def listdir(
+        self,
+        path: str | FsNode = "",
+        depth: int = 1,
+        exclude_self=True,
+        extra_properties: Sequence[str] | None = None,
+    ) -> list[FsNode]:
         """Returns a list of all entries in the specified directory.
 
         :param path: path to the directory to get the list.
         :param depth: how many directory levels should be included in output. Default = **1** (only specified directory)
         :param exclude_self: boolean value indicating whether the `path` itself should be excluded from the list or not.
             Default = **True**.
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
         """
         if exclude_self and not depth:
             raise ValueError("Wrong input parameters, query will return nothing.")
-        properties = get_propfind_properties(self._session.capabilities)
+        properties = get_propfind_properties(self._session.capabilities, extra_properties)
         path = path.user_path if isinstance(path, FsNode) else path
         return self._listdir(self._session.user, path, properties=properties, depth=depth, exclude_self=exclude_self)
 
-    def by_id(self, file_id: int | str | FsNode) -> FsNode | None:
+    def by_id(self, file_id: int | str | FsNode, extra_properties: Sequence[str] | None = None) -> FsNode | None:
         """Returns :py:class:`~nc_py_api.files.FsNode` by file_id if any.
 
         :param file_id: can be full file ID with Nextcloud instance ID or only clear file ID.
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
         """
         file_id = file_id.file_id if isinstance(file_id, FsNode) else file_id
-        result = self.find(req=["eq", "fileid", file_id])
+        result = self.find(req=["eq", "fileid", file_id], extra_properties=extra_properties)
         return result[0] if result else None
 
-    def by_path(self, path: str | FsNode) -> FsNode | None:
+    def by_path(self, path: str | FsNode, extra_properties: Sequence[str] | None = None) -> FsNode | None:
         """Returns :py:class:`~nc_py_api.files.FsNode` by exact path if any."""
         path = path.user_path if isinstance(path, FsNode) else path
-        result = self.listdir(path, depth=0, exclude_self=False)
+        result = self.listdir(path, depth=0, exclude_self=False, extra_properties=extra_properties)
         return result[0] if result else None
 
-    def find(self, req: list, path: str | FsNode = "") -> list[FsNode]:
+    def find(self, req: list, path: str | FsNode = "", extra_properties: Sequence[str] | None = None) -> list[FsNode]:
         """Searches a directory for a file or subdirectory with a name.
 
         :param req: list of conditions to search for. Detailed description here...
         :param path: path where to search from. Default = **""**.
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
         """
         # `req` possible keys: "name", "mime", "last_modified", "size", "favorite", "fileid"
-        root = build_find_request(req, path, self._session.user, self._session.capabilities)
+        root = build_find_request(req, path, self._session.user, self._session.capabilities, extra_properties)
         webdav_response = self._session.adapter_dav.request(
             "SEARCH", "", data=element_tree_as_str(root), headers={"Content-Type": "text/xml"}
         )
@@ -248,15 +264,21 @@ class FilesAPI:
         return self.find(req=["eq", "fileid", response.headers["OC-FileId"]])[0]
 
     def list_by_criteria(
-        self, properties: list[str] | None = None, tags: list[int | SystemTag] | None = None
+        self,
+        properties: list[str] | None = None,
+        tags: list[int | SystemTag] | None = None,
+        extra_properties: Sequence[str] | None = None,
     ) -> list[FsNode]:
         """Returns a list of all files/directories for the current user filtered by the specified values.
 
         :param properties: List of ``properties`` that should have been set for the file.
             Supported values: **favorite**
         :param tags: List of ``tags ids`` or ``SystemTag`` that should have been set for the file.
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
         """
-        root = build_list_by_criteria_req(properties, tags, self._session.capabilities)
+        root = build_list_by_criteria_req(properties, tags, self._session.capabilities, extra_properties)
         webdav_response = self._session.adapter_dav.request(
             "REPORT", dav_get_obj_path(self._session.user), data=element_tree_as_str(root)
         )
@@ -277,13 +299,19 @@ class FilesAPI:
         )
         check_error(webdav_response, f"setfav: path={path}, value={value}")
 
-    def trashbin_list(self) -> list[FsNode]:
-        """Returns a list of all entries in the TrashBin."""
+    def trashbin_list(self, extra_properties: Sequence[str] | None = None) -> list[FsNode]:
+        """Returns a list of all entries in the TrashBin.
+
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
+        """
         properties = [
             *PROPFIND_PROPERTIES,
             "nc:trashbin-filename",
             "nc:trashbin-original-location",
             "nc:trashbin-deletion-time",
+            *_validate_extra_properties(extra_properties, PROPFIND_PROPERTIES),
         ]
         return self._listdir(
             self._session.user, "", properties=properties, depth=1, exclude_self=False, prop_type=PropFindType.TRASHBIN
@@ -322,13 +350,18 @@ class FilesAPI:
         """Empties the TrashBin."""
         check_error(self._session.adapter_dav.delete(f"/trashbin/{self._session.user}/trash"))
 
-    def get_versions(self, file_object: FsNode) -> list[FsNode]:
-        """Returns a list of all file versions if any."""
+    def get_versions(self, file_object: FsNode, extra_properties: Sequence[str] | None = None) -> list[FsNode]:
+        """Returns a list of all file versions if any.
+
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
+        """
         require_capabilities("files.versioning", self._session.capabilities)
         return self._listdir(
             self._session.user,
             str(file_object.info.fileid) if file_object.info.fileid else file_object.file_id,
-            properties=PROPFIND_PROPERTIES,
+            properties=[*PROPFIND_PROPERTIES, *_validate_extra_properties(extra_properties, PROPFIND_PROPERTIES)],
             depth=1,
             exclude_self=False,
             prop_type=PropFindType.VERSIONS_FILEID if file_object.info.fileid else PropFindType.VERSIONS_FILE_ID,

--- a/nc_py_api/files/files_async.py
+++ b/nc_py_api/files/files_async.py
@@ -15,6 +15,7 @@ from . import FsNode, LockType, SystemTag
 from ._files import (
     PROPFIND_PROPERTIES,
     PropFindType,
+    _validate_extra_properties,
     build_find_request,
     build_list_by_criteria_req,
     build_list_tag_req,
@@ -43,45 +44,64 @@ class AsyncFilesAPI:
         self._session = session
         self.sharing = _AsyncFilesSharingAPI(session)
 
-    async def listdir(self, path: str | FsNode = "", depth: int = 1, exclude_self=True) -> list[FsNode]:
+    async def listdir(
+        self,
+        path: str | FsNode = "",
+        depth: int = 1,
+        exclude_self=True,
+        extra_properties: Sequence[str] | None = None,
+    ) -> list[FsNode]:
         """Returns a list of all entries in the specified directory.
 
         :param path: path to the directory to get the list.
         :param depth: how many directory levels should be included in output. Default = **1** (only specified directory)
         :param exclude_self: boolean value indicating whether the `path` itself should be excluded from the list or not.
             Default = **True**.
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
         """
         if exclude_self and not depth:
             raise ValueError("Wrong input parameters, query will return nothing.")
-        properties = get_propfind_properties(await self._session.capabilities)
+        properties = get_propfind_properties(await self._session.capabilities, extra_properties)
         path = path.user_path if isinstance(path, FsNode) else path
         return await self._listdir(
             await self._session.user, path, properties=properties, depth=depth, exclude_self=exclude_self
         )
 
-    async def by_id(self, file_id: int | str | FsNode) -> FsNode | None:
+    async def by_id(self, file_id: int | str | FsNode, extra_properties: Sequence[str] | None = None) -> FsNode | None:
         """Returns :py:class:`~nc_py_api.files.FsNode` by file_id if any.
 
         :param file_id: can be full file ID with Nextcloud instance ID or only clear file ID.
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
         """
         file_id = file_id.file_id if isinstance(file_id, FsNode) else file_id
-        result = await self.find(req=["eq", "fileid", file_id])
+        result = await self.find(req=["eq", "fileid", file_id], extra_properties=extra_properties)
         return result[0] if result else None
 
-    async def by_path(self, path: str | FsNode) -> FsNode | None:
+    async def by_path(self, path: str | FsNode, extra_properties: Sequence[str] | None = None) -> FsNode | None:
         """Returns :py:class:`~nc_py_api.files.FsNode` by exact path if any."""
         path = path.user_path if isinstance(path, FsNode) else path
-        result = await self.listdir(path, depth=0, exclude_self=False)
+        result = await self.listdir(path, depth=0, exclude_self=False, extra_properties=extra_properties)
         return result[0] if result else None
 
-    async def find(self, req: list, path: str | FsNode = "") -> list[FsNode]:
+    async def find(
+        self, req: list, path: str | FsNode = "", extra_properties: Sequence[str] | None = None
+    ) -> list[FsNode]:
         """Searches a directory for a file or subdirectory with a name.
 
         :param req: list of conditions to search for. Detailed description here...
         :param path: path where to search from. Default = **""**.
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
         """
         # `req` possible keys: "name", "mime", "last_modified", "size", "favorite", "fileid"
-        root = build_find_request(req, path, await self._session.user, await self._session.capabilities)
+        root = build_find_request(
+            req, path, await self._session.user, await self._session.capabilities, extra_properties
+        )
         webdav_response = await self._session.adapter_dav.request(
             "SEARCH", "", data=element_tree_as_str(root), headers={"Content-Type": "text/xml"}
         )
@@ -252,15 +272,21 @@ class AsyncFilesAPI:
         return (await self.find(req=["eq", "fileid", response.headers["OC-FileId"]]))[0]
 
     async def list_by_criteria(
-        self, properties: list[str] | None = None, tags: list[int | SystemTag] | None = None
+        self,
+        properties: list[str] | None = None,
+        tags: list[int | SystemTag] | None = None,
+        extra_properties: Sequence[str] | None = None,
     ) -> list[FsNode]:
         """Returns a list of all files/directories for the current user filtered by the specified values.
 
         :param properties: List of ``properties`` that should have been set for the file.
             Supported values: **favorite**
         :param tags: List of ``tags ids`` or ``SystemTag`` that should have been set for the file.
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
         """
-        root = build_list_by_criteria_req(properties, tags, await self._session.capabilities)
+        root = build_list_by_criteria_req(properties, tags, await self._session.capabilities, extra_properties)
         webdav_response = await self._session.adapter_dav.request(
             "REPORT", dav_get_obj_path(await self._session.user), data=element_tree_as_str(root)
         )
@@ -281,13 +307,19 @@ class AsyncFilesAPI:
         )
         check_error(webdav_response, f"setfav: path={path}, value={value}")
 
-    async def trashbin_list(self) -> list[FsNode]:
-        """Returns a list of all entries in the TrashBin."""
+    async def trashbin_list(self, extra_properties: Sequence[str] | None = None) -> list[FsNode]:
+        """Returns a list of all entries in the TrashBin.
+
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
+        """
         properties = [
             *PROPFIND_PROPERTIES,
             "nc:trashbin-filename",
             "nc:trashbin-original-location",
             "nc:trashbin-deletion-time",
+            *_validate_extra_properties(extra_properties, PROPFIND_PROPERTIES),
         ]
         return await self._listdir(
             await self._session.user,
@@ -331,13 +363,18 @@ class AsyncFilesAPI:
         """Empties the TrashBin."""
         check_error(await self._session.adapter_dav.delete(f"/trashbin/{await self._session.user}/trash"))
 
-    async def get_versions(self, file_object: FsNode) -> list[FsNode]:
-        """Returns a list of all file versions if any."""
+    async def get_versions(self, file_object: FsNode, extra_properties: Sequence[str] | None = None) -> list[FsNode]:
+        """Returns a list of all file versions if any.
+
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
+        """
         require_capabilities("files.versioning", await self._session.capabilities)
         return await self._listdir(
             await self._session.user,
             str(file_object.info.fileid) if file_object.info.fileid else file_object.file_id,
-            properties=PROPFIND_PROPERTIES,
+            properties=[*PROPFIND_PROPERTIES, *_validate_extra_properties(extra_properties, PROPFIND_PROPERTIES)],
             depth=1,
             exclude_self=False,
             prop_type=PropFindType.VERSIONS_FILEID if file_object.info.fileid else PropFindType.VERSIONS_FILE_ID,

--- a/nc_py_api/files/files_async.py
+++ b/nc_py_api/files/files_async.py
@@ -82,7 +82,12 @@ class AsyncFilesAPI:
         return result[0] if result else None
 
     async def by_path(self, path: str | FsNode, extra_properties: Sequence[str] | None = None) -> FsNode | None:
-        """Returns :py:class:`~nc_py_api.files.FsNode` by exact path if any."""
+        """Returns :py:class:`~nc_py_api.files.FsNode` by exact path if any.
+
+        :param extra_properties: additional WebDAV properties to request, e.g. ``["nc:has-preview"]``. They are
+            returned in :py:attr:`~nc_py_api.files.FsNode.extra_properties`, and must use the ``d``, ``oc``
+            or ``nc`` namespace.
+        """
         path = path.user_path if isinstance(path, FsNode) else path
         result = await self.listdir(path, depth=0, exclude_self=False, extra_properties=extra_properties)
         return result[0] if result else None
@@ -319,8 +324,8 @@ class AsyncFilesAPI:
             "nc:trashbin-filename",
             "nc:trashbin-original-location",
             "nc:trashbin-deletion-time",
-            *_validate_extra_properties(extra_properties, PROPFIND_PROPERTIES),
         ]
+        properties += _validate_extra_properties(extra_properties, properties)
         return await self._listdir(
             await self._session.user,
             "",

--- a/tests/actual_tests/files_test.py
+++ b/tests/actual_tests/files_test.py
@@ -1319,11 +1319,14 @@ def test_etag_is_accepted_by_server_as_is(nc_any):
     nc_any.files.delete("test_etag_as_is.txt", not_fail=True)
 
 
-def _test_extra_properties(node: FsNode):
+# the trashbin and versions endpoints answer 404 for some properties, so less is expected from them
+FULL_EXTRA_PROPERTIES = ("nc:has-preview", "oc:owner-id", "oc:share-types")
+
+
+def _test_extra_properties(node: FsNode, expected: tuple[str, ...] = FULL_EXTRA_PROPERTIES):
+    for key in expected:
+        assert key in node.extra_properties, f"`{key}` missing from {sorted(node.extra_properties)}"
     assert node.extra_properties["nc:has-preview"] in ("true", "false")
-    assert node.extra_properties["oc:owner-id"]
-    # `oc:share-types` is requested by default, so it shows up without being asked for
-    assert "oc:share-types" in node.extra_properties
 
 
 def test_extra_properties(nc_any):
@@ -1331,10 +1334,38 @@ def test_extra_properties(nc_any):
     nc_any.files.mkdir("test_extra_props")
     try:
         nc_any.files.upload("test_extra_props/a.txt", b"content")
+        nc_any.files.upload("test_extra_props/a.txt", b"content2")  # a second version
+        nc_any.files.setfav("test_extra_props/a.txt", True)
         extra = ["nc:has-preview", "oc:owner-id"]
-        _test_extra_properties(nc_any.files.by_path("test_extra_props/a.txt", extra_properties=extra))
+        node = nc_any.files.by_path("test_extra_props/a.txt", extra_properties=extra)
+        _test_extra_properties(node)
         _test_extra_properties(nc_any.files.listdir("test_extra_props", extra_properties=extra)[0])
         _test_extra_properties(nc_any.files.find(["like", "name", "a%"], "test_extra_props", extra_properties=extra)[0])
+        _test_extra_properties(nc_any.files.by_id(node, extra_properties=extra))
+        favorites = nc_any.files.list_by_criteria(properties=["favorite"], extra_properties=extra)
+        _test_extra_properties(next(i for i in favorites if i.name == "a.txt"))
+        versions = nc_any.files.get_versions(node, extra_properties=extra)
+        if versions:  # versioning may be disabled on the server
+            _test_extra_properties(versions[0], ("nc:has-preview",))
+        nc_any.files.upload("test_extra_props/gone.txt", b"x")
+        nc_any.files.delete("test_extra_props/gone.txt")
+        trashed = [i for i in nc_any.files.trashbin_list(extra_properties=extra) if "gone.txt" in i.name]
+        _test_extra_properties(trashed[0], ("nc:has-preview",))
+        # a property the TrashBin listing requests anyway must not be sent twice
+        requested: list[str] = []
+        original_listdir = nc_any.files._listdir
+        nc_any.files._listdir = lambda user, path, **kw: (
+            requested.extend(kw["properties"]),
+            original_listdir(user, path, **kw),
+        )[1]
+        try:
+            nc_any.files.trashbin_list(extra_properties=["nc:trashbin-filename", "nc:has-preview"])
+        finally:
+            nc_any.files._listdir = original_listdir
+        assert len(requested) == len(
+            set(requested)
+        ), f"duplicates: {sorted({i for i in requested if requested.count(i) > 1})}"
+        assert "nc:has-preview" in requested
         # without asking for them, only the properties that are requested anyway are reported
         plain = nc_any.files.by_path("test_extra_props/a.txt")
         assert "nc:has-preview" not in plain.extra_properties
@@ -1343,6 +1374,7 @@ def test_extra_properties(nc_any):
             nc_any.files.listdir("test_extra_props", extra_properties=["invalid:property"])
     finally:
         nc_any.files.delete("test_extra_props", not_fail=True)
+        nc_any.files.trashbin_cleanup()
 
 
 @pytest.mark.asyncio(scope="session")
@@ -1351,14 +1383,28 @@ async def test_extra_properties_async(anc_any):
     await anc_any.files.mkdir("test_extra_props")
     try:
         await anc_any.files.upload("test_extra_props/a.txt", b"content")
+        await anc_any.files.upload("test_extra_props/a.txt", b"content2")
+        await anc_any.files.setfav("test_extra_props/a.txt", True)
         extra = ["nc:has-preview", "oc:owner-id"]
-        _test_extra_properties(await anc_any.files.by_path("test_extra_props/a.txt", extra_properties=extra))
+        node = await anc_any.files.by_path("test_extra_props/a.txt", extra_properties=extra)
+        _test_extra_properties(node)
         _test_extra_properties((await anc_any.files.listdir("test_extra_props", extra_properties=extra))[0])
         found = await anc_any.files.find(["like", "name", "a%"], "test_extra_props", extra_properties=extra)
         _test_extra_properties(found[0])
+        _test_extra_properties(await anc_any.files.by_id(node, extra_properties=extra))
+        favorites = await anc_any.files.list_by_criteria(properties=["favorite"], extra_properties=extra)
+        _test_extra_properties(next(i for i in favorites if i.name == "a.txt"))
+        versions = await anc_any.files.get_versions(node, extra_properties=extra)
+        if versions:
+            _test_extra_properties(versions[0], ("nc:has-preview",))
+        await anc_any.files.upload("test_extra_props/gone.txt", b"x")
+        await anc_any.files.delete("test_extra_props/gone.txt")
+        trashed = [i for i in await anc_any.files.trashbin_list(extra_properties=extra) if "gone.txt" in i.name]
+        _test_extra_properties(trashed[0], ("nc:has-preview",))
         plain = await anc_any.files.by_path("test_extra_props/a.txt")
         assert "nc:has-preview" not in plain.extra_properties
         with pytest.raises(ValueError):
             await anc_any.files.listdir("test_extra_props", extra_properties=["invalid:property"])
     finally:
         await anc_any.files.delete("test_extra_props", not_fail=True)
+        await anc_any.files.trashbin_cleanup()

--- a/tests/actual_tests/files_test.py
+++ b/tests/actual_tests/files_test.py
@@ -1401,8 +1401,26 @@ async def test_extra_properties_async(anc_any):
         await anc_any.files.delete("test_extra_props/gone.txt")
         trashed = [i for i in await anc_any.files.trashbin_list(extra_properties=extra) if "gone.txt" in i.name]
         _test_extra_properties(trashed[0], ("nc:has-preview",))
+        # a property the TrashBin listing requests anyway must not be sent twice
+        requested: list[str] = []
+        original_listdir = anc_any.files._listdir
+
+        async def _spy(user, path, **kw):
+            requested.extend(kw["properties"])
+            return await original_listdir(user, path, **kw)
+
+        anc_any.files._listdir = _spy
+        try:
+            await anc_any.files.trashbin_list(extra_properties=["nc:trashbin-filename", "nc:has-preview"])
+        finally:
+            anc_any.files._listdir = original_listdir
+        assert len(requested) == len(
+            set(requested)
+        ), f"duplicates: {sorted({i for i in requested if requested.count(i) > 1})}"
+        assert "nc:has-preview" in requested
         plain = await anc_any.files.by_path("test_extra_props/a.txt")
         assert "nc:has-preview" not in plain.extra_properties
+        assert "oc:share-types" in plain.extra_properties
         with pytest.raises(ValueError):
             await anc_any.files.listdir("test_extra_props", extra_properties=["invalid:property"])
     finally:

--- a/tests/actual_tests/files_test.py
+++ b/tests/actual_tests/files_test.py
@@ -1317,3 +1317,48 @@ def test_etag_is_accepted_by_server_as_is(nc_any):
     )
     assert overwritten.status_code in (200, 204)
     nc_any.files.delete("test_etag_as_is.txt", not_fail=True)
+
+
+def _test_extra_properties(node: FsNode):
+    assert node.extra_properties["nc:has-preview"] in ("true", "false")
+    assert node.extra_properties["oc:owner-id"]
+    # `oc:share-types` is requested by default, so it shows up without being asked for
+    assert "oc:share-types" in node.extra_properties
+
+
+def test_extra_properties(nc_any):
+    nc_any.files.delete("test_extra_props", not_fail=True)
+    nc_any.files.mkdir("test_extra_props")
+    try:
+        nc_any.files.upload("test_extra_props/a.txt", b"content")
+        extra = ["nc:has-preview", "oc:owner-id"]
+        _test_extra_properties(nc_any.files.by_path("test_extra_props/a.txt", extra_properties=extra))
+        _test_extra_properties(nc_any.files.listdir("test_extra_props", extra_properties=extra)[0])
+        _test_extra_properties(nc_any.files.find(["like", "name", "a%"], "test_extra_props", extra_properties=extra)[0])
+        # without asking for them, only the properties that are requested anyway are reported
+        plain = nc_any.files.by_path("test_extra_props/a.txt")
+        assert "nc:has-preview" not in plain.extra_properties
+        assert "oc:share-types" in plain.extra_properties
+        with pytest.raises(ValueError):
+            nc_any.files.listdir("test_extra_props", extra_properties=["invalid:property"])
+    finally:
+        nc_any.files.delete("test_extra_props", not_fail=True)
+
+
+@pytest.mark.asyncio(scope="session")
+async def test_extra_properties_async(anc_any):
+    await anc_any.files.delete("test_extra_props", not_fail=True)
+    await anc_any.files.mkdir("test_extra_props")
+    try:
+        await anc_any.files.upload("test_extra_props/a.txt", b"content")
+        extra = ["nc:has-preview", "oc:owner-id"]
+        _test_extra_properties(await anc_any.files.by_path("test_extra_props/a.txt", extra_properties=extra))
+        _test_extra_properties((await anc_any.files.listdir("test_extra_props", extra_properties=extra))[0])
+        found = await anc_any.files.find(["like", "name", "a%"], "test_extra_props", extra_properties=extra)
+        _test_extra_properties(found[0])
+        plain = await anc_any.files.by_path("test_extra_props/a.txt")
+        assert "nc:has-preview" not in plain.extra_properties
+        with pytest.raises(ValueError):
+            await anc_any.files.listdir("test_extra_props", extra_properties=["invalid:property"])
+    finally:
+        await anc_any.files.delete("test_extra_props", not_fail=True)

--- a/tests_unit/test_extra_properties.py
+++ b/tests_unit/test_extra_properties.py
@@ -90,3 +90,19 @@ def test_fs_node_without_extra_properties():
 def test_xml_attributes_are_not_reported_as_properties():
     node = _parse_record("files/admin/a.txt", [_prop_stat({"@xmlns:d": "DAV:", "nc:has-preview": "true"})])
     assert node.extra_properties == {"nc:has-preview": "true"}
+
+
+WITH_LOCKING = {"files": {"locking": "1.0"}}  # `files.locking` advertised -> the lock properties are requested too
+
+
+def test_extra_properties_are_deduplicated_against_the_locking_ones():
+    from nc_py_api.files._files import PROPFIND_LOCKING_PROPERTIES
+
+    requested = get_propfind_properties(WITH_LOCKING, ["nc:lock-owner", "nc:has-preview"])
+    assert requested == [*PROPFIND_PROPERTIES, *PROPFIND_LOCKING_PROPERTIES, "nc:has-preview"]
+
+
+def test_extra_properties_come_after_the_default_ones():
+    requested = get_propfind_properties(WITH_LOCKING, ["nc:has-preview"])
+    assert requested[-1] == "nc:has-preview"
+    assert len(requested) == len(set(requested))

--- a/tests_unit/test_extra_properties.py
+++ b/tests_unit/test_extra_properties.py
@@ -1,0 +1,92 @@
+"""Tests for requesting additional WebDAV properties and reading them back from FsNode."""
+
+import pytest
+
+from nc_py_api.files import FsNode
+from nc_py_api.files._files import (
+    MAPPED_PROPERTIES,
+    PROPFIND_PROPERTIES,
+    _parse_record,
+    get_propfind_properties,
+)
+
+NO_LOCKING = {"files": {}}  # `files.locking` not advertised, so only the base properties are requested
+
+
+def _prop_stat(props: dict, status: str = "HTTP/1.1 200 OK") -> dict:
+    return {"d:status": status, "d:prop": props}
+
+
+def test_no_extra_properties_keeps_the_default_request():
+    assert get_propfind_properties(NO_LOCKING) == list(PROPFIND_PROPERTIES)
+    assert get_propfind_properties(NO_LOCKING, []) == list(PROPFIND_PROPERTIES)
+    assert get_propfind_properties(NO_LOCKING, None) == list(PROPFIND_PROPERTIES)
+
+
+def test_extra_properties_are_appended_in_order():
+    requested = get_propfind_properties(NO_LOCKING, ["nc:has-preview", "oc:owner-id"])
+    assert requested == [*PROPFIND_PROPERTIES, "nc:has-preview", "oc:owner-id"]
+
+
+def test_extra_properties_are_deduplicated():
+    # neither against each other nor against what is requested anyway
+    requested = get_propfind_properties(NO_LOCKING, ["nc:has-preview", "nc:has-preview", "oc:size", "d:getetag"])
+    assert requested == [*PROPFIND_PROPERTIES, "nc:has-preview"]
+
+
+def test_extra_properties_reject_unknown_namespaces():
+    for invalid in ("bogus:prop", "has-preview", ":has-preview"):
+        with pytest.raises(ValueError, match="Invalid property"):
+            get_propfind_properties(NO_LOCKING, [invalid])
+
+
+def test_unmapped_properties_land_in_extra_properties():
+    node = _parse_record(
+        "files/admin/a.txt",
+        [_prop_stat({"oc:id": "00000123", "oc:fileid": "123", "nc:has-preview": "true", "oc:owner-id": "admin"})],
+    )
+    assert node.file_id == "00000123"  # modelled fields stay where they were
+    assert node.info.fileid == 123
+    assert node.extra_properties == {"nc:has-preview": "true", "oc:owner-id": "admin"}
+
+
+def test_modelled_properties_are_not_duplicated_into_extra_properties():
+    node = _parse_record(
+        "files/admin/a.txt",
+        [_prop_stat(dict.fromkeys(MAPPED_PROPERTIES, "1"))],
+    )
+    assert node.extra_properties == {}
+
+
+def test_properties_the_server_could_not_return_are_ignored():
+    node = _parse_record(
+        "files/admin/a.txt",
+        [
+            _prop_stat({"nc:has-preview": "true"}),
+            _prop_stat({"nc:made-up-property": None}, status="HTTP/1.1 404 Not Found"),
+        ],
+    )
+    assert node.extra_properties == {"nc:has-preview": "true"}
+
+
+def test_values_are_kept_as_the_server_sent_them():
+    # strings, None for empty ones and a dict for the nested ones such as `oc:share-types`
+    node = _parse_record(
+        "files/admin/a.txt",
+        [_prop_stat({"oc:share-types": {"oc:share-type": "3"}, "nc:mount-type": None, "nc:has-preview": "true"})],
+    )
+    assert node.extra_properties == {
+        "oc:share-types": {"oc:share-type": "3"},
+        "nc:mount-type": None,
+        "nc:has-preview": "true",
+    }
+
+
+def test_fs_node_without_extra_properties():
+    assert FsNode("files/admin/a.txt").extra_properties == {}
+    assert FsNode("files/admin/a.txt", extra_properties=None).extra_properties == {}
+
+
+def test_xml_attributes_are_not_reported_as_properties():
+    node = _parse_record("files/admin/a.txt", [_prop_stat({"@xmlns:d": "DAV:", "nc:has-preview": "true"})])
+    assert node.extra_properties == {"nc:has-preview": "true"}


### PR DESCRIPTION
`FsNode` models a fixed set of WebDAV properties and the parser dropped everything else, so there was no way to read anything the library does not know about. Mutating `PROPFIND_PROPERTIES` was the only lever, and #453 closed it by making the constants tuples.

```python
nodes = nc.files.listdir("/photos", extra_properties=["nc:has-preview", "oc:owner-id"])
nodes[0].extra_properties["nc:has-preview"]   # 'true'
```

- `extra_properties` on `listdir`, `by_path`, `by_id`, `find`, `list_by_criteria`, `trashbin_list` and `get_versions`, sync and async
- new `FsNode.extra_properties` holds every returned property `FsNode` does not model itself, values as the server sent them: `str`, `None` when empty, `dict` for nested ones such as `oc:share-types`
- this also surfaces properties that were already requested and then thrown away: `oc:share-types`, `oc:checksums`, `oc:dDC`, `nc:is-encrypted`
- names are validated against the namespaces the requests declare (`d`, `oc`, `nc`) and deduplicated against the defaults

Note that `extra_properties` is therefore rarely empty: a normal listing carries `oc:share-types` even when nothing was requested.

10 unit tests and integration tests for both APIs; value shapes were taken from a live server, not assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional support for requesting additional WebDAV properties across synchronous and asynchronous file listing, lookup, search, filtering, TrashBin, and version APIs.
  - Returned file nodes now expose requested, unmodeled properties through `extra_properties`.
  - Added validation for property namespaces and automatic handling of duplicate or unavailable properties.

- **Documentation**
  - Updated the changelog and API documentation with details about requesting extra properties.

- **Tests**
  - Added coverage for valid, invalid, missing, default, and server-provided extra properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->